### PR TITLE
BI-972 - Testing Automation Framework (TAF) Button ID selectors

### DIFF
--- a/src/page_objects/page.js
+++ b/src/page_objects/page.js
@@ -65,7 +65,7 @@ module.exports = {
     loggedInAsLabel:
       "#app > div.sidebarlayout > div > div:nth-child(2) > main > div > div.level-right > div:nth-child(1) > p",
     logoutButton:
-      "#app > div.sidebarlayout > div > div:nth-child(2) > main > div > div.level-right > div:nth-child(2) > button",
+      "#basesidebarlayout-logout-button",
 
     programsLabel: {
       selector: "//*[@id='app']//main//section//h1[text()=' Programs ']",

--- a/src/step_definitions/steps.js
+++ b/src/step_definitions/steps.js
@@ -817,14 +817,14 @@ Then(
   /^user can see a button 'Download the Trait Import Template'$/,
   async () => {
     await page.assert.containsText(
-      "#download-trait-template", "Download the Trait Import Template"
+      "#traitimporttemplatemessagebox-download-trait-template", "Download the Trait Import Template"
     );
   }
 );
 
 Then(/^user can see a button 'Choose a file...'$/, async () => {
   await page.assert.containsText(
-    "#choose-file > span:nth-child(2)",
+    "#fileselector-choose-file > span:nth-child(2)",
     "Choose a file..."
   );
 });
@@ -845,13 +845,13 @@ Then(/^user can see "([^"]*)" displayed$/, async (args1) => {
 
 Then(/^user cans see 'Choose a different file...' button$/, async () => {
   await page.assert.visible(
-    "#choose-different-file"
+    "#fileselector-choose-different-file"
   );
 });
 
 Then(/^user can see 'Import' button$/, async () => {
   await page.assert.visible(
-    "#import-button"
+    "#fileselectmessagebox-import-button"
   );
 });
 
@@ -942,13 +942,13 @@ Then(
 
 Then(/^user can see 'Yes, abort' button$/, async () => {
   await page.assert.containsText(
-    "#yes-abort", "Yes, abort"
+    "#traitsimport-yes-abort", "Yes, abort"
   );
 });
 
 When(/^user selects 'Import' button$/, async () => {
   await page.click(
-    "#import-button"
+    "#fileselectmessagebox-import-button"
   );
   await page.pause(3000);
 });
@@ -969,7 +969,7 @@ Then(
 
 When(/^user selects 'Yes, abort' button$/, async () => {
   await page.click(
-    "#yes-abort"
+    "#traitsimport-yes-abort"
   );
 });
 


### PR DESCRIPTION
Modifying steps in TAF to use new ID selectors for buttons rather than xpaths.

Linked to https://github.com/Breeding-Insight/bi-web/pull/97 which adds the necessary IDs 

Buttons (with associated TAF scenario for testing)
- Download the Trait Import Template (BI-809)
- Choose a file… (BI-809, BI-810)
- Choose a different file… (BI-917, BI-923)
- Import (BI-810, BI-917)
- Yes, abort (BI-919, BI-921)
- Log out (BI-803)
- Home (BI-822)
- Program Management (BI-822)
- Traits (BI-822)
- Import File
- BrAPI

(Note: BI-917, BI-923, and BI-921 have steps with non-button selectors that are failing)

[BI-972]: https://breedinginsight.atlassian.net/browse/BI-972