### PR TITLE
[1025] - Uploaded filename selector

### DIFF
--- a/src/step_definitions/steps.js
+++ b/src/step_definitions/steps.js
@@ -839,7 +839,7 @@ When(/^user uploads "([^"]*)" file$/, async (args1) => {
 
 Then(/^user can see "([^"]*)" displayed$/, async (args1) => {
   await page.assert.containsText(
-    "#app > div.sidebarlayout > div > div:nth-child(2) > main > section > div > div > div.file-select > div > article > nav > div.level-left > div:nth-child(1) > div",
+    "#fileselectmessagebox-import-filename",
     args1
   );
 });


### PR DESCRIPTION
The TAF tests checking for the display of uploaded filename are currently failing.

Added an id to the div with the filename in FileSelectMessageBox.vue

Associated with PR [bi-web/1025](https://github.com/Breeding-Insight/bi-web/pull/102)
