### PR TITLE
[BI-1026] - BRAPI url, Program, Location fixes

### DIFF
--- a/src/features/ProgramManagement.feature
+++ b/src/features/ProgramManagement.feature
@@ -87,8 +87,8 @@ Feature: Program Management (15)
 			| Program | Sweet Potato | 0       | System Default |
 
 		Examples:
-			| Name    | Species      |
-			| Program | Sweet Potato |
+			| Name     | Species      |
+			| Program* | Sweet Potato |
 
 	@BI-853
 	Scenario Outline: New Program, invalid url in custom storage location
@@ -99,15 +99,13 @@ Feature: Program Management (15)
 		When user checks 'Specify custom program data storage location' checkbox in Programs page
 		When user sets "<BrAPI URL>" in BrAPI URL field in Programs page
 		When user selects 'Save' button in Programs page
-		Then user can not see 'Program Form' in Programs page
-		Then user can see "Success! <Name> added." in banner
-		Then user can see new program in Programs page
-			| Name   | Species   | # Users | BrAPI URL                            |
-			| <Name> | <Species> | 0       | https://<BrAPI URL>-server.brapi.org |
+		Then user can see 'Program Form' in Programs page
+		Then user can see "BrAPI URL must be in url format, ex: https://test-server.brapi.org" text under BrAPI URL field in Programs page
+		Then user can see banner contains 'Fix Invalid Fields'
 
 		Examples:
-			| Name    | Species      | BrAPI URL |
-			| Program | Sweet Potato | test      |
+			| Name     | Species      | BrAPI URL |
+			| Program* | Sweet Potato | test      |
 
 	@BI-854
 	Scenario Outline: New Program, invalid BrAPI storage location
@@ -122,8 +120,8 @@ Feature: Program Management (15)
 		Then user can see "BrAPI URL specified is not supported" text under BrAPI URL field in Programs page
 
 		Examples:
-			| Name    | Species      | BrAPI URL                |
-			| Program | Sweet Potato | http://brapiserver:8080/ |
+			| Name     | Species      | BrAPI URL                |
+			| Program* | Sweet Potato | http://brapiserver:8080/ |
 
 	@BI-855
 	Scenario Outline: New Program, valid custom storage location
@@ -141,8 +139,8 @@ Feature: Program Management (15)
 			| <Name> | <Species> | 0       | <BrAPI URL> |
 
 		Examples:
-			| Name    | Species      | BrAPI URL                                |
-			| Program | Sweet Potato | http://qa-test1.breedinginsight.net:7080 |
+			| Name     | Species      | BrAPI URL                               |
+			| Program* | Sweet Potato | http://qa-test.breedinginsight.net:7080 |
 
 	@BI-856
 	Scenario Outline: Edit Program form

--- a/src/features/SmokeTests.feature
+++ b/src/features/SmokeTests.feature
@@ -64,7 +64,7 @@ Feature: Smoke Tests (11)
 		And user can see each row has a Deactivate link
 		Examples:
 			| location name |
-			| location1     |
+			| Location*     |
 
 	@BI-808
 	Scenario: Program Location Management page

--- a/src/page_objects/page.js
+++ b/src/page_objects/page.js
@@ -169,9 +169,14 @@ module.exports = {
       "#app > div:nth-child(1) > article:nth-child(1) > div > div > div > div > div:nth-child(2)",
 
     //location
-    newLocationButton: {
+    newLocationButtonNoLocsPresent: {
       selector:
         "//*[@id='emptyTableMessage']//button[normalize-space(.)='New Location']",
+      locateStrategy: "xpath",
+    },
+    newLocationButtonLocsPresent: {
+      selector:
+        "//*[@id='locationTableLabel']//button[normalize-space(.)='New Location']",
       locateStrategy: "xpath",
     },
 
@@ -342,10 +347,6 @@ module.exports = {
       selector: "#locationTableLabel",
       elements: {
         form: "form.new-form",
-        newLocationButton: {
-          selector: ".//button[normalize-space(.)='New Location']",
-          locateStrategy: "xpath",
-        },
         nameField: "#Name",
         saveButton: {
           selector: ".//span[normalize-space(.)='Save']/ancestor::button",

--- a/src/step_definitions/programSteps.js
+++ b/src/step_definitions/programSteps.js
@@ -195,17 +195,17 @@ Then(
 );
 
 When(/^user selects 'Edit' of "([^"]*)" in Programs page$/, async (args1) => {
-  let program;
+  let programName;
   if (program.Name != null) {
-    program = program.Name;
+    programName = program.Name;
   } else {
-    program = args1;
+    programName = args1;
   }
   const selector = {
-    selector: `.//td[@name='name'][normalize-space(.)='${program}']/ancestor::tr//td/a[normalize-space(.)='Edit']`,
+    selector: `.//td[@name='name'][normalize-space(.)='${programName}']/ancestor::tr//td/a[normalize-space(.)='Edit']`,
     locateStrategy: "xpath",
   };
-  await this.click(selector);
+  await page.click(selector);
 });
 
 Then(
@@ -329,7 +329,7 @@ Then(/^user can see "([^"]*)" archived in system in banner$/, async (args1) => {
 When(
   /^user selects 'New Location' button in Program Management page$/,
   async () => {
-    await page.section.locationForm.click("@newLocationButton");
+    await page.click("@newLocationButtonNoLocsPresent");
   }
 );
 
@@ -340,7 +340,11 @@ When(/^user selects 'Save' button in Program Management page$/, async () => {
 When(
   /^user sets "([^"]*)" in Name field in Program Management page$/,
   async (args1) => {
-    await page.section.locationForm.setValue("@nameField", args1);
+    this.location = {};
+    this.location.Name = args1.replace("*", Date.now().toString());
+    await page.section.locationForm.setValue(
+      "@nameField", 
+      this.location.Name)
   }
 );
 
@@ -354,7 +358,14 @@ Then(
 Then(
   /^user can see "([^"]*)" in Name column in Program Management page$/,
   async (args1) => {
-    await page.section.locationForm.isItemInNewRow({ Name: args1 });
+    let locationName;
+    if (typeof this.location !== 'undefined') {
+      locationName = this.location.Name;
+    }
+    else {
+      locationName=args1;
+    }
+    await page.section.locationForm.isItemInNewRow({ Name: locationName });
   }
 );
 
@@ -383,7 +394,7 @@ Then(
 Then(
   /^user can see 'Name is required' below the Name field in Program Management page$/,
   async () => {
-    await page.section.programManagement.section.form.visible(
+    await page.section.programManagement.section.form.assert.visible(
       "@nameIsRequiredText"
     );
   }

--- a/src/step_definitions/steps.js
+++ b/src/step_definitions/steps.js
@@ -351,15 +351,15 @@ When(/^user creates a new program$/, async (table) => {
     for (hash of table.hashes()) {
       switch (column) {
         case "Program Name":
-          this.program.name = hash["Program Name"].replace(
+          this.program.Name = hash["Program Name"].replace(
             "*",
             Date.now().toString()
           );
-          await programForm.setValue("@programNameField", this.program.name);
+          await programForm.setValue("@programNameField", this.program.Name);
           break;
         case "Species":
-          this.program.species = hash["Species"];
-          await programForm.setValue("@speciesSelect", this.program.species);
+          this.program.Species = hash["Species"];
+          await programForm.setValue("@speciesSelect", this.program.Species);
           break;
         default:
           throw new Error(`Unexpected ${column} name.`);
@@ -372,13 +372,13 @@ When(/^user creates a new program$/, async (table) => {
 Then(/^user can see a new program is created$/, async () => {
   await page.assert.containsText(
     "#adminProgramTableLabel table tr.is-new td:nth-child(1)",
-    this.program.name
+    this.program.Name
   );
   await page.assert.containsText(
     "#adminProgramTableLabel table tr.is-new td:nth-child(2)",
-    this.program.species
+    this.program.Species
   );
-  console.log("and this" + this.program.name);
+  console.log("and this" + this.program.Name);
 });
 
 When(/^user selects Cancel button$/, async () => {
@@ -477,7 +477,6 @@ When(/^user edits a user$/, async (table) => {
 });
 
 Then(/^user can see a new user is added in User$/, async () => {
-  await showAll();
   await page.assert.containsText("tr.is-new td[name='name']", user.userName);
   await page.assert.containsText("tr.is-new td[name='email']", user.email);
   await page.assert.containsText("tr.is-new td[name='roles']", user.role);
@@ -1015,11 +1014,6 @@ Then(/^user can see "([^"]*)" column in Users$/, async (args1) => {
   });
 });
 
-Then(/^user can see new user added in User$/, async () => {
-  await showAll();
-  await page.assert.visible("");
-});
-
 Then(/^user can see 'Previous' button$/, async () => {
   await page.assert.visible("@previousButton");
 });
@@ -1040,7 +1034,7 @@ Then(/^user can see Results Per Page dropdown$/, async () => {
 });
 
 Then(/^user can see 'New Location' in Locations$/, async () => {
-  await page.assert.visible("@newLocationButton");
+  await page.assert.visible("@newLocationButtonNoLocsPresent");
 });
 
 Then(/^user can see 'System Administration' title on Programs$/, async () => {


### PR DESCRIPTION
Fixes to TAF tests:

- Modified steps involving creating programs and locations to generate a unique program/location name
- Fixed BrAPI url for steps involving custom storage location
- Modified Scenario: New Program, invalid url in custom storage location to match specifications in BI-853
- Removed newLocationButton selectors and replaced them with newLocationButtonNoLocsPresent and newLocationButtonLocsPresent to properly select the correct "New Location" button depending on whether a location exists or not (due to there being two possible "New Location" buttons in the backend)
- Removed showAll() call before looking for newly added user to a program that was causing the page to refresh and thus no longer label the new program as new
- Minor typo fixes to get steps running

Notes:
* Currently tests are under the assumption that there are no existing locations associated with the program. Scenarios dealing with adding a location when location exists for the program will be added in a later JIRA.
