### PR TITLE
[BI-1030] Modal fixes

### DIFF
--- a/src/features/ProgramManagement.feature
+++ b/src/features/ProgramManagement.feature
@@ -219,7 +219,10 @@ Feature: Program Management (15)
 		When user selects "Sweet Potato" in Species dropdown in Programs page
 		When user selects 'Save' button in Programs page
 		When user selects 'Deactivate' of "<Name>" in Programs page
-		Then user can see 'Remove Alert' in modal in Programs page
+		Then user can see "Remove" in modal box header
+		Then user can see "<Name>" in modal box header
+		Then user can see "from the system?" in modal box header
+		Then user can see "Program-related data will not be affected by this change." in modal box text
 		Then user can see 'Yes, remove' button in modal in Programs page
 		Then user can see 'Cancel' button in modal in Programs page
 
@@ -236,7 +239,7 @@ Feature: Program Management (15)
 		When user selects 'Save' button in Programs page
 		When user selects 'Deactivate' of "<Name>" in Programs page
 		When user selects 'Cancel' button in modal in Programs page
-		Then user can not see 'Remove Alert' in modal in Programs page
+		Then user can not see a modal box
 		Then user can see "<Name>" in Name column in Program page
 
 		Examples:
@@ -244,22 +247,6 @@ Feature: Program Management (15)
 			| Program* |
 
 	@BI-862
-	Scenario Outline: Deactivate, Cancel
-		When user is on the program-management page
-		When user selects 'New Program' button in Programs page
-		When user sets "<Name>" in Program Name field in Programs page
-		When user selects "Sweet Potato" in Species dropdown in Programs page
-		When user selects 'Save' button in Programs page
-		When user selects 'Deactivate' of "<Name>" in Programs page
-		When user selects 'Cancel' button in modal in Programs page
-		Then user can not see 'Remove Alert' in modal in Programs page
-		Then user can see "<Name>" in Name column in Program page
-
-		Examples:
-			| Name     |
-			| Program* |
-
-	@BI-863
 	Scenario Outline: Deactivate, Remove
 		When user is on the program-management page
 		When user selects 'New Program' button in Programs page
@@ -268,6 +255,7 @@ Feature: Program Management (15)
 		When user selects 'Save' button in Programs page
 		When user selects 'Deactivate' of "<Name>" in Programs page
 		When user selects 'Yes, remove' button in modal in Programs page
+		Then user can not see a modal box
 		Then user can see "<Name>" archived in system in banner
 		Then user can not see "<Name>" in Name column in Program page
 

--- a/src/features/ProgramManagementLocationBreeder.feature
+++ b/src/features/ProgramManagementLocationBreeder.feature
@@ -237,21 +237,27 @@ Feature: Program Location Management
 			| member |
 		Then user can see user is in users list
 
-	@modal
 	@BI-900
-	Scenario: Deactivate link - modal
+	Scenario Outline: Deactivate link - modal
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
 		And user selects "Program Management" in navigation
 		And user selects "Users" in navigation
 		And user creates a new user
 			| Name   | Email                | Role    |
-			| Test * | test*@mailinator.com | breeder |
+			| User* | test*@mailinator.com | breeder |
 		When user selects Deactivate of user
-		Then user can see a modal with Deactivate message
-		Then user can see 'Yes, deactivate' button
+		Then user can see "Deactivate" in modal box header
+		Then user can see "<NameToDeactivate>" in modal box header
+		Then user can see "from program Snacks?" in modal box header
+		Then user can see "This will only remove the user's access to your program and will not affect their account." in modal box text
+		Then user can see "Program-related data collected by this user will not be affected by this change." in modal box text
+		Then user can see 'Yes, archive' button
 		And user can see 'Cancel' button
-		And user can see Save button
+
+	Examples: 
+    	| NameToDeactivate |
+		| User*       |
 
 	@BI-901
 	Scenario: Deactivate link - Cancel

--- a/src/features/TraitImportBreeder.feature
+++ b/src/features/TraitImportBreeder.feature
@@ -39,20 +39,18 @@ Feature: Trait Import (10 Scenarios)
 		And user can see "Scale" column header
 		And user can see each row has a "Show Details" link
 
-	@modal
 	@BI-919
 	Scenario: Traits - Abort Import, Modal
 		When user uploads "test_import-xls.xls" file
 		And user selects 'Import' button
 		And user selects "Abort" button
 		Then user can see a modal box
-		And user can see 'Abort This Import' in modal box
-		And user can see 'No traits will be added, and the import in progress will be completely removed.' in modal box
+		And user can see "Abort This Import" in modal box header
+		And user can see "No traits will be added, and the import in progress will be completely removed." in modal box text
 		And user can see 'Yes, abort' button
 		And user can see "Cancel" button
 		And user selects "Cancel" button
 
-	@modal
 	@BI-920
 	Scenario: Traits - Abort Import, Cancel
 		When user uploads "test_import-xls.xls" file

--- a/src/features/UserManagementBreeder.feature
+++ b/src/features/UserManagementBreeder.feature
@@ -204,21 +204,27 @@ Feature: Breeder User Management
 			| member |
 		Then user can see user is in users list
 
-	@modal
 	@BI-900
-	Scenario: Deactivate link - modal
+	Scenario Outline: Deactivate link - modal
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
 		And user selects "Program Management" in navigation
 		And user selects "Users" in navigation
 		And user creates a new user
 			| Name   | Email                | Role    |
-			| Test * | test*@mailinator.com | breeder |
+			| User* | test*@mailinator.com | breeder |
 		When user selects Deactivate of user
-		Then user can see a modal with Deactivate message
-		Then user can see 'Yes, deactivate' button
+		Then user can see "Deactivate" in modal box header
+		Then user can see "<NameToDeactivate>" in modal box header
+		Then user can see "from program Snacks?" in modal box header
+		Then user can see "This will only remove the user's access to your program and will not affect their account." in modal box text
+		Then user can see "Program-related data collected by this user will not be affected by this change." in modal box text
+		Then user can see 'Yes, archive' button
 		And user can see 'Cancel' button
-		And user can see Save button
+
+	Examples: 
+    	| NameToDeactivate |
+		| User*       |
 
 @BI-901
 	Scenario: Deactivate link - Cancel

--- a/src/features/UserManagementSysAd.feature
+++ b/src/features/UserManagementSysAd.feature
@@ -128,20 +128,28 @@ Feature: System User Management (15)
 		And user can see 'Cancel' button
 		And user selects 'Cancel' button
 
-	@modal
 	@BI-839
-	Scenario: User Deactivate link and Cancel
+	Scenario Outline: User Deactivate link and Cancel
 		Given user is on the user-management page
 		And user creates a new user
-			| Name   | Email                | Role    |
-			| Test * | test*@mailinator.com | breeder |
+			| Name       | Email                | Role    |
+			| User* | test*@mailinator.com | breeder |
 		When user selects Deactivate of user
-		Then user can see a modal with Deactivate message
+		Then user can see "Deactivate" in modal box header
+		Then user can see "<NameToDeactivate>" in modal box header
+		Then user can see "from the system?" in modal box header
+		Then user can see "Access for this user will be removed system wide." in modal box text
+		Then user can see "Program-related data collected by this user will not be affected by this change." in modal box text
 		And user can see 'Yes, deactivate' button
 		And user can see 'Cancel' button
 		When user selects 'Cancel' button
 		Then user can not see a modal box
 		Then user can see edited user in users list
+
+		Examples: 
+    		| NameToDeactivate |
+			| User*       |
+
 
 	@BI-840
 	Scenario: Deactivate link - Yes, deactivate

--- a/src/page_objects/page.js
+++ b/src/page_objects/page.js
@@ -183,6 +183,11 @@ module.exports = {
         "//*[@id='app']//main//section//button[normalize-space(.)='Yes, deactivate']",
       locateStrategy: "xpath",
     },
+    archiveButton: {
+      selector:
+        "//*[@id='app']//main//section//button[normalize-space(.)='Yes, archive']",
+      locateStrategy: "xpath",
+    },
 
     //modal
     modalCard: {
@@ -191,10 +196,6 @@ module.exports = {
     },
     modalHeader: {
       selector: "//div[@class='modal is-active']/div[@class='modal-card']//h3[contains(@class, 'modal-header')]",
-      locateStrategy: "xpath",
-    },
-    modalText: {
-      selector: "//div[@class='modal is-active']/div[@class='modal-card']//p[contains(@class, 'modal-text')]",
       locateStrategy: "xpath",
     },
   },
@@ -251,8 +252,6 @@ module.exports = {
           selector: ".//button[normalize-space(.)='Cancel'][@data-testid]",
           locateStrategy: "xpath",
         },
-        modalAlertMessage: "div.modal-card article h3",
-        modalMessage: "section p",
         yesRemoveButton: {
           selector:
             ".//div[@class='modal-card']//button[normalize-space(.)='Yes, remove']",

--- a/src/step_definitions/programSteps.js
+++ b/src/step_definitions/programSteps.js
@@ -50,17 +50,6 @@ Then(/^user can see 'Cancel' button in Programs page$/, async () => {
   await page.section.programForm.assert.visible("@cancelButton");
 });
 
-When(
-  /^user sets "([^"]*)" in Program Name field in Programs page$/,
-  async (args1) => {
-    await page.section.programForm.clearValue("@programNameField");
-    await page.section.programForm.setValue(
-      "@programNameField",
-      args1.replace("*", Date.now().toString())
-    );
-  }
-);
-
 When(/^user selects 'Save' button in Programs page$/, async () => {
   //read the final values of the fields and save it
   await page.section.programForm.getValue("@programNameField", ({ value }) => {
@@ -265,13 +254,6 @@ When(
   }
 );
 
-Then(/^user can see 'Remove Alert' in modal in Programs page$/, async () => {
-  await page.section.programForm.assert.containsText(
-    "@modalAlertMessage",
-    `Remove ${program.Name} from the system ?`
-  );
-});
-
 Then(
   /^user can see 'Yes, remove' button in modal in Programs page$/,
   async () => {
@@ -286,13 +268,6 @@ Then(/^user can see 'Cancel' button in modal in Programs page$/, async () => {
 When(/^user selects 'Cancel' button in modal in Programs page$/, async () => {
   await page.section.programForm.click("@cancelModalButton");
 });
-
-Then(
-  /^user can not see 'Remove Alert' in modal in Programs page$/,
-  async () => {
-    await page.section.programForm.assert.not.visible("@modalAlertMessage");
-  }
-);
 
 When(
   /^user selects 'Yes, remove' button in modal in Programs page$/,

--- a/src/step_definitions/steps.js
+++ b/src/step_definitions/steps.js
@@ -712,37 +712,12 @@ When(/^user selects Deactivate of user$/, async () => {
   });
 });
 
-Then(/^user can see a modal with Deactivate message$/, async () => {
-  const selector="@modalHeader";
-  await page.assert.visible(selector);
-
-  page.getText(selector, function(result) {
-    console.log(result.value);
-  });
-  
-  await page.assert.containsText(
-    selector,
-    `Deactivate ${user.userName} from program`
-  );
-
-  const messageText="@modalText";
-
-  page.getText(messageText, function(result) {
-    console.log(result.value);
-  });
-  await page.assert.containsText(
-    messageText,
-    "Access for this user will be removed system wide"
-  );
-  
-  await page.assert.containsText(
-    messageText,
-    "Program-related data collected by this user will not be affected by this change."
-  );
-});
-
 Then(/^user can see 'Yes, deactivate' button$/, async () => {
   await page.assert.visible("@deactivateButton");
+});
+
+Then(/^user can see 'Yes, archive' button$/, async () => {
+  await page.assert.visible("@archiveButton");
 });
 
 Then(/^user can see 'Cancel' button$/, async () => {
@@ -760,10 +735,7 @@ When(/^user selects 'Cancel' button$/, async () => {
 });
 
 When(/^user selects modal Yes, archive button$/, async () => {
-  await page.click({
-    selector: "//strong[normalize-space(.)='Yes, archive']/..",
-    locateStrategy: "xpath",
-  });
+  await page.click("@archiveButton");
 });
 
 Then(/^user can see "([^"]*)" in the the Role dropdown$/, async (args1) => {
@@ -892,19 +864,39 @@ Then(/^user can not see a modal box$/, async () => {
   await page.assert.not.elementPresent("@modalCard");
 });
 
-Then(/^user can see 'Abort This Import' in modal box$/, async () => {
-  await page.assert.containsText("@modalHeader", "Abort This Import");
+Then(/^user can see "([^"]*)" in modal box header$/, async (args1) => {
+  let headerText;
+  if (args1.includes("User*")) {
+    headerText = user.userName;
+  } else if(args1.includes("Program*")) {
+    headerText = this.program.Name;
+  } else {
+    headerText=args1;
+  }
+  await page.assert.containsText("@modalHeader", headerText);
 });
 
-//Todo maybe simplify steps checking for modal text
-Then(
-  /^user can see 'No traits will be added, and the import in progress will be completely removed.' in modal box$/,
-  async () => {
-    await page.assert.containsText(
-      "@modalText", "No traits will be added, and the import in progress will be completely removed."
+When(
+  /^user sets "([^"]*)" in Program Name field in Programs page$/,
+  async (args1) => {
+    await page.section.programForm.clearValue("@programNameField");
+    this.program = {};
+    this.program.Name = args1.replace("*", Date.now().toString());
+    await page.section.programForm.setValue(
+      "@programNameField",
+      this.program.Name
     );
   }
 );
+
+
+Then(/^user can see "([^"]*)" in modal box text$/, async (args1) => {
+    //Multiple text lines can exist, so selector needs to be specific to text
+    await page.assert.visible({
+      selector: `//div[@class="modal is-active"]/div[@class="modal-card"]//p[contains(@class, "modal-text") and contains(text(), "${args1}")]`,
+      locateStrategy: "xpath",
+    });
+});
 
 Then(/^user can see 'Yes, abort' button$/, async () => {
   await page.assert.containsText(


### PR DESCRIPTION
Streamlined modal tests to be more robust and to ensure failing modal test BI-900 passes (since it was originally using a step dependent on text for system user management as opposed to program user management).

- Steps "user can see <header text> in modal box header" and "user can see <text> in modal box text" will be used for modal header text and modal text respectively.
- Steps "user can see a modal box" and "user can not see a modal box" will be used for checking the presence of a modal box.
- Added general modalHeader and archiveButton selectors to page.js and removed program form-specific selectors modalAlertMessage and modalMessage 
- Simplified modalcard selector in page.js
- Added step to check for "Yes, archive" button
- Moved "user sets "([^"]*)" in Program Name field in Programs page" from programSteps.js to steps.js so program name could be passed to modal check.
- Removed scenario currently tagged BI-862 (which was just a duplicate of BI-861), and switched tag for scenario "Deactivate, Remove" from BI-863 to BI-862 as it has the content BI-862 should have.

**Note:** 
- As of now modal text steps have the same issue as banner text steps where checking for a string that includes both hard-coded text and a generated user name, program name, etc included cannot be done. For now, the modal checks have separate steps to check for the existence of the hard-coded text and the generated names rather than checking for the whole line. 
- Modal text selector not moved to page.js due to taking input from the steps (to handle case of multiple text elements in a modal).

This PR is linked to [bi-web/BI-1030](https://github.com/Breeding-Insight/bi-web/pull/103)