### PR TITLE
[BI-1072] Fix deactivated modal tests

### DIFF
--- a/src/features/UserManagementSysAd.feature
+++ b/src/features/UserManagementSysAd.feature
@@ -143,7 +143,8 @@ Feature: System User Management (15)
 			| Name       | Email                | Role    |
 			| User* | test*@mailinator.com | breeder |
 		When user selects Deactivate of user
-		And user selects 'Cancel' button
+		Then user can see a modal box
+		When user selects 'Cancel' button
 		Then user can not see a modal box
 		Then user can see edited user in users list
 


### PR DESCRIPTION
Fixed scenarios in TAF for BI-838 and BI-839 to better match what is in the JIRA cards.

Fixed checks for modal content in BI-838 (which wasn't accounted for in BI-1030)
Changed BI-839 to only check the results of clicking cancel on the modal, not the modal box content.