### PR TITLE
[BI-640] Disable modifying system role of self

### DIFF
--- a/src/features/UserManagementSysAd.feature
+++ b/src/features/UserManagementSysAd.feature
@@ -164,20 +164,17 @@ Feature: System User Management (15)
 		When user selects 'Edit' of "<Original Email>" of Users
 		And user sets "<New Name>" in Name field
 		And user sets "<New Email>" in Email field
-		And user sets "<New Role>" in Role dropdown
 		And user selects 'Save' button in Users
 		Then user can see banner contains "User info (name/email/program) successfully updated"
-		Then user can see banner contains "You don't have permissions to edit the roles of this user."
 		#CLEANUP
 		When user selects 'Edit' of "<New Email>" of Users
 		And user sets "<Original Name>" in Name field
 		And user sets "<Original Email>" in Email field
-		And user sets "<Original Role>" in Role dropdown
 		And user selects 'Save' button in Users 
 
 		Examples:
-			| Original Email           | Original Name | Original Role | New Name   | New Email               | New Role |
-			| christian@mailinator.com | Christian     | admin         | TestNew *  | testnew*@mailinator.com | No Role  |
+			| Original Email           | Original Name | New Name   | New Email               |
+			| christian@mailinator.com | Christian     | TestNew *  | testnew*@mailinator.com |
 	
 
 	#     Scenario: Editing form and selecting Save


### PR DESCRIPTION
The current messages when a sys admin modifies their own role and no other fields are confusing. To simplify this, the field for modifying a user's role will be disabled when the user is the same as the sys admin. This will break existing TAF scenario BI-836.

Changes:
- Modify BI-836 to no longer update user role and not check for error banner.

Linked to PR [bi-web/BI-640](https://github.com/Breeding-Insight/bi-web/pull/108)