### PR TITLE
[BI-1091] Fix Pagination Button selectors

### DIFF
--- a/src/page_objects/page.js
+++ b/src/page_objects/page.js
@@ -120,12 +120,12 @@ module.exports = {
     usersTable: "#app section table",
 
     nextButton: {
-      selector: "//*[@id='app']//a[normalize-space(.)='Next']",
+      selector: "//*[@id='app']//button[normalize-space(.)='Next']",
       locateStrategy: "xpath",
     },
 
     previousButton: {
-      selector: "//*[@id='app']//a[normalize-space(.)='Previous']",
+      selector: "//*[@id='app']//button[normalize-space(.)='Previous']",
       locateStrategy: "xpath",
     },
 
@@ -138,7 +138,7 @@ module.exports = {
       locateStrategy: "xpath",
     },
     showAllButton: {
-      selector: "//nav//a[normalize-space(.)='Show All']",
+      selector: "//nav//button[normalize-space(.)='Show All']",
       locateStrategy: "xpath",
     },
 


### PR DESCRIPTION
BI-1087 changed the pagination Next, Previous, and Show All elements from `<a>` to `<button>`. This affects selectors for TAF and currently causes scenarios to fail.

Update selectors for pagination elements Next, Previous, and Show All to look for `<button>`, not `<a>`.