### PR TITLE
[BI-1104] Update chromedriver for TAF

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@cucumber/cucumber": "^7.3.1",
     "@cucumber/pretty-formatter": "*",
     "@slime/stopwatch": "^1.0.5",
-    "chromedriver": "^91.0.0",
+    "chromedriver": "^93.0.0",
     "cucumber-html-reporter": "^5.2.0",
     "edgedriver": "^4.17134.1",
     "geckodriver": "^2.0.3",


### PR DESCRIPTION
Updated from version 91 to 93 due to chrome update.

This will require developers to either change their local version of TAF to work with their existing version of chrome, or update chrome and chromedriver.