### PR TITLE
[BI-1284] - TAF Chromedriver Update

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@cucumber/cucumber": "^7.3.1",
     "@cucumber/pretty-formatter": "*",
     "@slime/stopwatch": "^1.0.5",
-    "chromedriver": "^95.0.0",
+    "chromedriver": "^97.0.0",
     "cucumber-html-reporter": "^5.2.0",
     "edgedriver": "^4.17134.1",
     "geckodriver": "^2.0.3",


### PR DESCRIPTION
Updated ChromeDriver from 95 to 97 to support Chrome version 97.0.4692.71