### PR TITLE
Bug/bi 915

### DIFF
--- a/src/features/LoginByRoleMemberTests.feature
+++ b/src/features/LoginByRoleMemberTests.feature
@@ -42,11 +42,11 @@ Feature: Logging with Member
 	#To ensure there is at least one location in list of locations in Snacks
 	#Scenario will still pass with no locations, but won't test the lack of Edit and Deactivate links
 	@BI-915
+	@debug
 	Scenario: Program Location Management page - member - SETUP
 		Given user logs in as "Cucumber Breeder"
 		When user selects "Snacks" on program-selection page
 		When user selects "Program Management" in navigation
-		When user selects "Locations" in sub-level navigation
 		When user selects 'New Location' button in Program Management page
 		When user sets "<location name>" in Name field in Program Management page
 		When user selects 'Save' button in Program Management page
@@ -55,10 +55,10 @@ Feature: Logging with Member
 			| Location*     |
 
 	@BI-915
+	@debug
 	Scenario: Program Location Management page - member
 		Given user logs in as "Cucumber Member"
 		And user selects "Program Management" in navigation
-		When user selects "Locations" in sub-level navigation
 		Then user can not see "Edit" link 
 		And user can not see "Deactivate" link
 		Then user can not see 'New Location' button in Program Management page

--- a/src/features/LoginByRoleMemberTests.feature
+++ b/src/features/LoginByRoleMemberTests.feature
@@ -42,7 +42,6 @@ Feature: Logging with Member
 	#To ensure there is at least one location in list of locations in Snacks
 	#Scenario will still pass with no locations, but won't test the lack of Edit and Deactivate links
 	@BI-915
-	@debug
 	Scenario: Program Location Management page - member - SETUP
 		Given user logs in as "Cucumber Breeder"
 		When user selects "Snacks" on program-selection page
@@ -55,7 +54,6 @@ Feature: Logging with Member
 			| Location*     |
 
 	@BI-915
-	@debug
 	Scenario: Program Location Management page - member
 		Given user logs in as "Cucumber Member"
 		And user selects "Program Management" in navigation


### PR DESCRIPTION
# Description
**Story:** 
https://breedinginsight.atlassian.net/browse/BI-915

Remove "When user selects "Locations" in sub-level navigation" step since after selecting Program Management, the page lands on Location tab by default.


# Dependencies
None

# Testing
https://github.com/Breeding-Insight/taf/actions/runs/2048819084

This test run only validates the BI-915 test cases (2) are passing.
Other failures are not related or directly caused by the changes I made.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation

