### PR TITLE
Bug/bi 1519

### DIFF
--- a/src/features/OntologyTermCreateMethodScaleClassBehavior.feature
+++ b/src/features/OntologyTermCreateMethodScaleClassBehavior.feature
@@ -134,11 +134,11 @@ Feature: Ontology Term Create - Method & Scale Class Behavior
         And user clears Value first field on ontology list page
         And user clears Value second field on ontology list page
         And user selects 'Save' button on ontology list page
-        Then user can see "Value missing." below Value first field on ontology list page
+        Then user can see "1" in Category first field on ontology list page
         Then user can see "Label missing." error message below Category first field on ontology list page
-        Then user can see "Value missing." below Value second field on ontology list page
+        Then user can see "2" in Category second field on ontology list page
         Then user can see "Label missing." below Category second field on ontology list page
-        Then user can see banner appears with an error message "Error creating trait. Scale categories contain errors; Ordinal scales must have at least two categories.;"
+        Then user can see banner appears with an error message "Error creating trait. Scale categories contain errors;"
 
         Examples:
             | ont_term_name | trait_description | trait_entity | trait_attribute | method_description |

--- a/src/features/OntologyTermCreateMethodScaleClassBehavior.feature
+++ b/src/features/OntologyTermCreateMethodScaleClassBehavior.feature
@@ -121,7 +121,7 @@ Feature: Ontology Term Create - Method & Scale Class Behavior
         Then user can see Category fourth field on ontology list page
 
     @htest
-    @BI-1344
+    @BI-1519
     Scenario: scale class Ordinal - required fields
         Given user selects 'New Term' button on ontology list page
         Given user sets "<ont_term_name>" in 'Name' field on ontology list page


### PR DESCRIPTION
# Description
Update BI-1344 to BI-1519.
Category fields are automatically populated when empty after clicking Save.
Update the expected error message.

# Dependencies
None

# Testing
https://github.com/Breeding-Insight/taf/actions/runs/2554020033

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
