### PR TITLE
Bug/bi 1551

### DIFF
--- a/src/features/OntologyTermCreateGeneralBehavior.feature
+++ b/src/features/OntologyTermCreateGeneralBehavior.feature
@@ -55,7 +55,6 @@ Feature: Ontology Term Create - General Behavior
         Then user can see "Test1, FullName1" in Synonyms text on ontology list page
 
     @BI-1518
-    @debug
     Scenario: Ontology Term Create - Required Fields
         When user selects 'New Term' button on ontology list page
         When user selects 'Save' button on ontology list page
@@ -123,11 +122,15 @@ Feature: Ontology Term Create - General Behavior
         Then user can see "Method1 Observation" in 'Method' text on ontology list page
 
     @BI-1312
+    @debug
     Scenario: Ontology Term Create - Name & Method Description - Character Limits
         Given user selects 'New Term' button on ontology list page
         When user sets as is "ThisNameWithMoreThanTwelveCharacters" in 'Name' field on ontology list page
-        When user sets "ThisDescriptionContainsMoreThanThirtyCharacters" in 'Method Description' field on ontology list page
+        When user sets "ThisDescription" in 'Method Description' field on ontology list page
         When user selects 'Save' button on ontology list page
         Then user can see "Name must be less than 12 characters." below the 'Name' field on ontology list page
+        When user sets as is "ThisNameWith" in 'Name' field on ontology list page
+        When user sets "ThisDescriptionIsMoreThanThirtyCharacters" in 'Method Description' field on ontology list page
+        When user selects 'Save' button on ontology list page
         Then user can see "Description must be less than 30 characters." below the 'Method Description' field on ontology list page
         Then user can see banner appears with an error message "Fix Invalid Fields"

--- a/src/page_objects/ontologyPage.js
+++ b/src/page_objects/ontologyPage.js
@@ -26,7 +26,7 @@ module.exports = {
         nameField: "#Name",
         nameErrorText: {
           selector: "span.form-error.has-text-danger",
-          index: 1,
+          index: 0,
         },
         fullNameField: "#Full-name",
         entitySelectField: {
@@ -58,8 +58,8 @@ module.exports = {
         methodDescription:
           "form > div.columns.is-multiline.is-gapless.is-vcentered > div:nth-child(23) > div > div.field-body > div > div > div > div.control.is-clearfix > input",
         methodDescriptionErrorText: {
-          selector: "//span[normalize-space(.)='Missing method description']",
-          locateStrategy:"xpath",
+          selector: "span.form-error.has-text-danger",
+          index: 3,
         },
         methodClass:
           "form > div.columns.is-multiline.is-gapless.is-vcentered > div:nth-child(25) > div > div.field-body > div > div > div > select",

--- a/src/page_objects/ontologyPage.js
+++ b/src/page_objects/ontologyPage.js
@@ -24,9 +24,9 @@ module.exports = {
       selector: "#ontologyTableLabel",
       elements: {
         nameField: "#Name",
-        nameErrorText: {
-          selector: "span.form-error.has-text-danger",
-          index: 0,
+        errorText: {
+          selector: "//span[@class='form-error has-text-danger']",
+          locateStrategy: "xpath",
         },
         fullNameField: "#Full-name",
         entitySelectField: {

--- a/src/step_definitions/ontologySteps.js
+++ b/src/step_definitions/ontologySteps.js
@@ -265,21 +265,30 @@ When(
 When(
   /^user sets "([^"]*)" in Ordinal first field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.setValue("@firstScaleField", args1);
+    await ontologyPage.section.allTraitsForm.setValue(
+      "@firstScaleField",
+      args1
+    );
   }
 );
 
 When(
   /^user sets "([^"]*)" in Ordinal second field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.setValue("@secondScaleField", args1);
+    await ontologyPage.section.allTraitsForm.setValue(
+      "@secondScaleField",
+      args1
+    );
   }
 );
 
 When(
   /^user sets "([^"]*)" in Ordinal third field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.setValue("@thirdScaleField", args1);
+    await ontologyPage.section.allTraitsForm.setValue(
+      "@thirdScaleField",
+      args1
+    );
   }
 );
 
@@ -305,96 +314,80 @@ Then(
 Then(
   /^user can see "([^"]*)" below the 'Name' field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.assert.visible("@errorText");
-    await ontologyPage.section.allTraitsForm.assert.containsText(
-      "@errorText",
-      args1
-    );
+    await ontologyPage.section.allTraitsForm.assert.visible({
+      selector: `//span[@class='form-error has-text-danger'][normalize-space()='${args1}']`,
+      locateStrategy: "xpath",
+    });
   }
 );
 
 Then(
   /^user can see "([^"]*)" below the 'Description' field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.assert.visible(
-      "@desriptionErrorText"
-    );
-    await ontologyPage.section.allTraitsForm.assert.containsText(
-      "@desriptionErrorText",
-      args1
-    );
+    await ontologyPage.section.allTraitsForm.assert.visible({
+      selector: `//span[@class='form-error has-text-danger'][normalize-space()='${args1}']`,
+      locateStrategy: "xpath",
+    });
   }
 );
 
 Then(
   /^user can see "([^"]*)" below the 'Entity' field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.assert.visible("@entityErrorText");
-    await ontologyPage.section.allTraitsForm.assert.containsText(
-      "@entityErrorText",
-      args1
-    );
+    await ontologyPage.section.allTraitsForm.assert.visible({
+      selector: `//span[@class='form-error has-text-danger'][normalize-space()='${args1}']`,
+      locateStrategy: "xpath",
+    });
   }
 );
 
 Then(
   /^user can see "([^"]*)" below the 'Attribute' field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.assert.visible(
-      "@attributeErrorText"
-    );
-    await ontologyPage.section.allTraitsForm.assert.containsText(
-      "@attributeErrorText",
-      args1
-    );
+    await ontologyPage.section.allTraitsForm.assert.visible({
+      selector: `//span[@class='form-error has-text-danger'][normalize-space()='${args1}']`,
+      locateStrategy: "xpath",
+    });
   }
 );
 
 Then(
   /^user can see "([^"]*)" below the 'Method Description' field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.assert.visible(
-      "@methodDescriptionErrorText"
-    );
-    await ontologyPage.section.allTraitsForm.assert.containsText(
-      "@methodDescriptionErrorText",
-      args1
-    );
+    await ontologyPage.section.allTraitsForm.assert.visible({
+      selector: `//span[@class='form-error has-text-danger'][normalize-space()='${args1}']`,
+      locateStrategy: "xpath",
+    });
   }
 );
 
 Then(
   /^user can not see "([^"]*)" below the 'Method Description' field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.assert.not.elementPresent(
-      "@methodDescriptionErrorText"
-    );
+    await ontologyPage.section.allTraitsForm.assert.not.elementPresent({
+      selector: `//span[@class='form-error has-text-danger'][normalize-space()='${args1}']`,
+      locateStrategy: "xpath",
+    });
   }
 );
 
 Then(
   /^user can see "([^"]*)" below the 'Method Class' dropdown on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.assert.visible(
-      "@methodClassErrorText"
-    );
-    await ontologyPage.section.allTraitsForm.assert.containsText(
-      "@methodClassErrorText",
-      args1
-    );
+    await ontologyPage.section.allTraitsForm.assert.visible({
+      selector: `//span[@class='form-error has-text-danger'][normalize-space()='${args1}']`,
+      locateStrategy: "xpath",
+    });
   }
 );
 
 Then(
   /^user can see "([^"]*)" below the 'Scale Class' dropdown on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.assert.visible(
-      "@scaleClassErrorText"
-    );
-    await ontologyPage.section.allTraitsForm.assert.containsText(
-      "@scaleClassErrorText",
-      args1
-    );
+    await ontologyPage.section.allTraitsForm.assert.visible({
+      selector: `//span[@class='form-error has-text-danger'][normalize-space()='${args1}']`,
+      locateStrategy: "xpath",
+    });
   }
 );
 
@@ -519,7 +512,9 @@ Then(
 Then(
   /^user can see "([^"]*)" below the 'Formula' field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.assert.visible("@formulaErrorText");
+    await ontologyPage.section.allTraitsForm.assert.visible(
+      "@formulaErrorText"
+    );
     await ontologyPage.section.allTraitsForm.assert.containsText(
       "@formulaErrorText",
       args1
@@ -611,7 +606,10 @@ Then(/^user can see 'Unit of time' field on ontology list page$/, async () => {
 When(
   /^user set "([^"]*)" in 'Unit' field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.setValue("@unitofTimeField", args1);
+    await ontologyPage.section.allTraitsForm.setValue(
+      "@unitofTimeField",
+      args1
+    );
   }
 );
 
@@ -652,7 +650,9 @@ Then(
 Then(
   /^user can see "([^"]*)" placeholder in Nominal second field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.assert.visible("@secondScaleField");
+    await ontologyPage.section.allTraitsForm.assert.visible(
+      "@secondScaleField"
+    );
     await ontologyPage.section.allTraitsForm.assert.attributeEquals(
       "@secondScaleField",
       "placeholder",
@@ -694,7 +694,9 @@ Then(
 Then(
   /^user can see "([^"]*)" placeholder in Nominal fourth field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.assert.visible("@fourthScaleField");
+    await ontologyPage.section.allTraitsForm.assert.visible(
+      "@fourthScaleField"
+    );
     await ontologyPage.section.allTraitsForm.assert.attributeEquals(
       "@fourthScaleField",
       "placeholder",
@@ -1090,7 +1092,10 @@ When(
 When(
   /^user sets "([^"]*)" in Nominal third field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.setValue("@thirdScaleField", args1);
+    await ontologyPage.section.allTraitsForm.setValue(
+      "@thirdScaleField",
+      args1
+    );
   }
 );
 
@@ -1142,14 +1147,20 @@ Then(
 When(
   /^user sets "([^"]*)" in Ordinal first value field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.setValue("@firstValueField", args1);
+    await ontologyPage.section.allTraitsForm.setValue(
+      "@firstValueField",
+      args1
+    );
   }
 );
 
 When(
   /^user sets "([^"]*)" in Ordinal third value field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.setValue("@thirdValueField", args1);
+    await ontologyPage.section.allTraitsForm.setValue(
+      "@thirdValueField",
+      args1
+    );
   }
 );
 
@@ -1214,19 +1225,27 @@ Then(
 );
 
 Then(/^user can see Category first field on ontology list page$/, async () => {
-  await ontologyPage.section.allTraitsForm.assert.visible("@firstCategoryField");
+  await ontologyPage.section.allTraitsForm.assert.visible(
+    "@firstCategoryField"
+  );
 });
 
 Then(/^user can see Category second field on ontology list page$/, async () => {
-  await ontologyPage.section.allTraitsForm.assert.visible("@secondCategoryField");
+  await ontologyPage.section.allTraitsForm.assert.visible(
+    "@secondCategoryField"
+  );
 });
 
 Then(/^user can see Category third field on ontology list page$/, async () => {
-  await ontologyPage.section.allTraitsForm.assert.visible("@thirdCategoryField");
+  await ontologyPage.section.allTraitsForm.assert.visible(
+    "@thirdCategoryField"
+  );
 });
 
 Then(/^user can see Category fourth field on ontology list page$/, async () => {
-  await ontologyPage.section.allTraitsForm.assert.visible("@fourthCategoryField");
+  await ontologyPage.section.allTraitsForm.assert.visible(
+    "@fourthCategoryField"
+  );
 });
 
 Then(/^user can see Value first field on ontology list page$/, async () => {
@@ -1534,8 +1553,9 @@ Then(
     );
     await ontologyPage.assert.containsText(
       {
-        selector: "//div[@class='is-full-length trait-detail']//div[@class='column']",
-        index:0,
+        selector:
+          "//div[@class='is-full-length trait-detail']//div[@class='column']",
+        index: 0,
         locateStrategy: "xpath",
       },
       traitObject.categoryFirstField
@@ -1552,8 +1572,9 @@ Then(
     );
     await ontologyPage.assert.containsText(
       {
-        selector: "//div[@class='is-full-length trait-detail']//div[@class='column']",
-        index:1,
+        selector:
+          "//div[@class='is-full-length trait-detail']//div[@class='column']",
+        index: 1,
         locateStrategy: "xpath",
       },
       traitObject.categorySecondField

--- a/src/step_definitions/ontologySteps.js
+++ b/src/step_definitions/ontologySteps.js
@@ -305,9 +305,9 @@ Then(
 Then(
   /^user can see "([^"]*)" below the 'Name' field on ontology list page$/,
   async (args1) => {
-    await ontologyPage.section.allTraitsForm.assert.visible("@nameErrorText");
+    await ontologyPage.section.allTraitsForm.assert.visible("@errorText");
     await ontologyPage.section.allTraitsForm.assert.containsText(
-      "@nameErrorText",
+      "@errorText",
       args1
     );
   }


### PR DESCRIPTION
# Description
BI-1551 - Updated the selector for error messages on Ontology page.
Use the text to locate the message since the error message changes their index.


# Dependencies
None


# Testing
[_Please include a link to a successful run of TAF for this change_](https://github.com/Breeding-Insight/taf/actions/runs/2744294894)


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
