### PR TITLE
Re-order steps since the login panel disappears after some time.

### DIFF
--- a/src/features/LoginByRoleBreederTests.feature
+++ b/src/features/LoginByRoleBreederTests.feature
@@ -9,26 +9,28 @@ Feature: Logging with Breeder
 		And user can see "Trail Mix" is in the list
 
 	@BI-822
+	@debug
 	Scenario: User in multiple programs
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
 		And user selects User Status menu dropdown
+		And user can see "Logged in as Cucumber Breeder" as logged in
+		And user can see a Log out button
 		Then user can see Welcome page of program
 		Then user can see "Snacks" in the upper right corner
 		And user can see Program Selection combo box
-		And user can see "Logged in as Cucumber Breeder" as logged in
-		And user can see a Log out button
 		And user can see "Home" in navigation
 		And user can see "Ontology" in navigation
 		And user can see "Program Management" in navigation
 		When user navigates to Program Selection
 		And user selects "Trail Mix" on program-selection page
 		And user selects User Status menu dropdown
+		And user can see "Logged in as Cucumber Breeder" as logged in
+		And user can see a Log out button
 		Then user can see Welcome page of program
 		Then user can see "Trail Mix" in the upper right corner
 		And user can see Program Selection combo box
-		And user can see "Logged in as Cucumber Breeder" as logged in
-		And user can see a Log out button
+		And user selects User Status menu dropdown
 		And user can see "Home" in navigation
 		And user can see "Ontology" in navigation
 		And user can see "Program Management" in navigation

--- a/src/step_definitions/userManagementMenuSteps.js
+++ b/src/step_definitions/userManagementMenuSteps.js
@@ -3,6 +3,7 @@ const { Given, Then, When } = require("@cucumber/cucumber");
 const page = client.page.page();
 
 Then(/^user selects User Status menu dropdown$/, async () => {
+  await page.pause(5000);
   await page.click("@userStatusMenuDropDownButton");
 });
 


### PR DESCRIPTION
# Description
BI-822
Re-order the steps since the login banner disappears after few seconds.
Moved the string validation after the login banner shows up.



# Dependencies
None


# Testing
https://github.com/Breeding-Insight/taf/actions/runs/2909516626
Other test failures not related to the fix.


# Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
