### PR TITLE
BI-1651 - Allow programs to choose/create breeding methods

### DIFF
--- a/populate-taf-data.sql
+++ b/populate-taf-data.sql
@@ -72,4 +72,7 @@ INSERT INTO program_user_role (program_id, user_id, role_id, created_by, updated
 SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'Christian' and role.domain = 'breeder'
 JOIN program ON program.name = 'Trail Mix';
 
+INSERT INTO program_enabled_breeding_methods(breeding_method_id, program_id, created_by, created_at, updated_by, updated_at)
+SELECT breeding_method.id, program.id, (SELECT id FROM bi_user WHERE name = 'system'), now(), (SELECT id FROM bi_user WHERE name = 'system'), now() FROM breeding_method, program;
+
 END $$;

--- a/src/features/Configuration.feature
+++ b/src/features/Configuration.feature
@@ -17,7 +17,7 @@ Feature: Ontology Sharing
         When user pause for "10" seconds
         When user navigates to Program Selection page
         When user selects "<ProgramName>" on program-selection page
-        When user selects "Program Management" in navigation
+        When user selects "Program Administration" in navigation
         When user selects "Users" tab
         When user clicks 'New User' button
         When user sets "Cucumber Breeder" in Name field of User
@@ -30,7 +30,7 @@ Feature: Ontology Sharing
         #Login as Cucumber Breeder and go to Snacks
         When user logs in as "Cucumber Breeder"
         When user selects "Snacks" on program-selection page
-        When user selects "Program Management" in navigation
+        When user selects "Program Administration" in navigation
         Then user can see 'Ontology Sharing' tab on Program Management page
         When user selects "Ontology Sharing" tab on Program Management page
         Then user can see Ontology Sharing on Program Management page
@@ -46,7 +46,7 @@ Feature: Ontology Sharing
         #Go to new Program and check the shared ontology
         When user navigates to Program Selection page
         When user selects "<ProgramName>" on program-selection page
-        When user selects "Program Management" in navigation
+        When user selects "Program Administration" in navigation
         Then user can see 'Ontology Sharing' tab on Program Management page
         When user selects "Ontology Sharing" tab on Program Management page
         Then user can see Ontology Sharing on Program Management page
@@ -58,7 +58,7 @@ Feature: Ontology Sharing
         #Go to Snacks and remove the shared ontology
         When user navigates to Program Selection page
         When user selects "Snacks" on program-selection page
-        When user selects "Program Management" in navigation
+        When user selects "Program Administration" in navigation
         Then user can see 'Ontology Sharing' tab on Program Management page
         When user selects "Ontology Sharing" tab on Program Management page
         Then user can see Ontology Sharing on Program Management page

--- a/src/features/Configuration.feature
+++ b/src/features/Configuration.feature
@@ -1,12 +1,12 @@
 
-Feature: Configuration
+Feature: Ontology Sharing
 
     Background: Required Setup
         Given user logs in as "sysad"
         And user selects "System Administration" on program-selection page
 
     @BI-1502
-    Scenario Outline: Configuration as a sub-menu
+    Scenario Outline: Ontology Sharing as a sub-menu
         When user is on the program-management page
         #Create a new program
         When user selects 'New Program' button in Programs page
@@ -31,11 +31,11 @@ Feature: Configuration
         When user logs in as "Cucumber Breeder"
         When user selects "Snacks" on program-selection page
         When user selects "Program Management" in navigation
-        Then user can see 'Configuration' tab on Program Management page
-        When user selects "Configuration" tab on Program Management page
-        Then user can see Configuration on Program Management page
-        Then user can see "Shared Ontology" section on Configuration tab on Program Management page
-        Then user can see "Snacks is not currently sharing their ontology with other programs." message on Configuration tab on Program Management page
+        Then user can see 'Ontology Sharing' tab on Program Management page
+        When user selects "Ontology Sharing" tab on Program Management page
+        Then user can see Ontology Sharing on Program Management page
+        Then user can see "Shared Ontology" section on Ontology Sharing tab on Program Management page
+        Then user can see "Snacks is not currently sharing their ontology with other programs." message on Ontology Sharing tab on Program Management page
         When user selects Share Ontology button of Shared Ontology on Program Management page
         When user can see the 'Manage  Share Ontology' in Managed Shared Ontlogy page
         Then user can see "<ProgramName>" checkbox in Managed Shared Ontlogy page
@@ -47,10 +47,10 @@ Feature: Configuration
         When user navigates to Program Selection page
         When user selects "<ProgramName>" on program-selection page
         When user selects "Program Management" in navigation
-        Then user can see 'Configuration' tab on Program Management page
-        When user selects "Configuration" tab on Program Management page
-        Then user can see Configuration on Program Management page
-        Then user can see "Shared Ontology" section on Configuration tab on Program Management page
+        Then user can see 'Ontology Sharing' tab on Program Management page
+        When user selects "Ontology Sharing" tab on Program Management page
+        Then user can see Ontology Sharing on Program Management page
+        Then user can see "Shared Ontology" section on Ontology Sharing tab on Program Management page
         When user selects "Snacks" in Choose ontology to subscribe to dropdown on Program Management page
         When user selects Save button of Subscribe to Shared Ontology on Program Management page
         When user pause for "5" seconds
@@ -59,15 +59,15 @@ Feature: Configuration
         When user navigates to Program Selection page
         When user selects "Snacks" on program-selection page
         When user selects "Program Management" in navigation
-        Then user can see 'Configuration' tab on Program Management page
-        When user selects "Configuration" tab on Program Management page
-        Then user can see Configuration on Program Management page
-        Then user can see "Shared Ontology" section on Configuration tab on Program Management page
+        Then user can see 'Ontology Sharing' tab on Program Management page
+        When user selects "Ontology Sharing" tab on Program Management page
+        Then user can see Ontology Sharing on Program Management page
+        Then user can see "Shared Ontology" section on Ontology Sharing tab on Program Management page
         Then user can see "<ProgramName>" is currently shared and accepted message
         When user selects Share Ontology button of Shared Ontology on Program Management page
         When user selects "<ProgramName>" checkbox in Managed Shared Ontlogy page
         When user selects "Save" button in Managed Shared Ontlogy page
-        Then user can see "Snacks is not currently sharing their ontology with other programs." message on Configuration tab on Program Management page
+        Then user can see "Snacks is not currently sharing their ontology with other programs." message on Ontology Sharing tab on Program Management page
     
         Examples:
             | ProgramName | Key | Species |

--- a/src/features/ExperimentsImport.feature
+++ b/src/features/ExperimentsImport.feature
@@ -18,7 +18,7 @@ Feature: Experiments & Observations
         When user pause for "10" seconds
         When user navigates to Program Selection page
         When user selects "<ProgramName>" on program-selection page
-        When user selects "Program Management" in navigation
+        When user selects "Program Administration" in navigation
         When user selects "Users" tab
         When user clicks 'New User' button
         When user sets "Cucumber Breeder" in Name field of User

--- a/src/features/GermplasmSort.feature
+++ b/src/features/GermplasmSort.feature
@@ -14,7 +14,7 @@ Feature: Germplasm Sort Test
 		When user pause for "10" seconds
 		When user navigates to Program Selection page
 		When user selects "<Program Name>" on program-selection page
-		When user selects "Program Management" in navigation
+		When user selects "Program Administration" in navigation
 		When user selects "Users" tab
 		When user clicks 'New User' button
 		When user sets "Cucumber Breeder" in Name field of User

--- a/src/features/LoginByRoleAdminTests.feature
+++ b/src/features/LoginByRoleAdminTests.feature
@@ -61,4 +61,4 @@ Feature: Logging with Sys Administration
 		And user can see "Trail Mix" as label in the bottom of the navigation menu
 		And user can see "Home" in navigation
 		And user can see "Ontology" in navigation
-		And user can see "Program Management" in navigation
+		And user can see "Program Administration" in navigation

--- a/src/features/LoginByRoleBreederTests.feature
+++ b/src/features/LoginByRoleBreederTests.feature
@@ -20,7 +20,7 @@ Feature: Logging with Breeder
 		And user can see Program Selection combo box
 		And user can see "Home" in navigation
 		And user can see "Ontology" in navigation
-		And user can see "Program Management" in navigation
+		And user can see "Program Administration" in navigation
 		When user navigates to Program Selection
 		And user selects "Trail Mix" on program-selection page
 		And user selects User Status menu dropdown
@@ -32,6 +32,6 @@ Feature: Logging with Breeder
 		And user selects User Status menu dropdown
 		And user can see "Home" in navigation
 		And user can see "Ontology" in navigation
-		And user can see "Program Management" in navigation
+		And user can see "Program Administration" in navigation
 
 	

--- a/src/features/LoginByRoleMemberTests.feature
+++ b/src/features/LoginByRoleMemberTests.feature
@@ -10,7 +10,7 @@ Feature: Logging with Member
 		And user can see a Log out button
 		And user can see "Home" in navigation
 		And user can see "Ontology" in navigation
-		And user can see "Program Management" in navigation
+		And user can see "Program Administration" in navigation
 
 	@BI-823
 	Scenario: Logging in as a breeder of one program
@@ -22,7 +22,7 @@ Feature: Logging with Member
 		And user can see a Log out button
 		And user can see "Home" in navigation
 		And user can see "Ontology" in navigation
-		And user can see "Program Management" in navigation
+		And user can see "Program Administration" in navigation
 
 	@BI-845
 	Scenario: Logging in as a breeder of one program
@@ -33,7 +33,7 @@ Feature: Logging with Member
 	@BI-887
 	Scenario: No Admin role, Program Member - Program User Management
 		Given user logs in as "Cucumber Member"
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		Then user can not see New User button
 		And user can see each row does not have an "Edit" link
@@ -45,7 +45,7 @@ Feature: Logging with Member
 	Scenario: Program Location Management page - member - SETUP
 		Given user logs in as "Cucumber Breeder"
 		When user selects "Snacks" on program-selection page
-		When user selects "Program Management" in navigation
+		When user selects "Program Administration" in navigation
 		When user selects "Locations" tab
 		When user selects 'New Location' button in Program Management page
 		When user sets "<location name>" in Name field in Program Management page
@@ -57,7 +57,7 @@ Feature: Logging with Member
 	@BI-915
 	Scenario: Program Location Management page - member
 		Given user logs in as "Cucumber Member"
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Locations" tab
 		Then user can not see "Edit" link 
 		And user can not see "Deactivate" link

--- a/src/features/LoginByRoleMemberTests.feature
+++ b/src/features/LoginByRoleMemberTests.feature
@@ -46,6 +46,7 @@ Feature: Logging with Member
 		Given user logs in as "Cucumber Breeder"
 		When user selects "Snacks" on program-selection page
 		When user selects "Program Management" in navigation
+		When user selects "Locations" tab
 		When user selects 'New Location' button in Program Management page
 		When user sets "<location name>" in Name field in Program Management page
 		When user selects 'Save' button in Program Management page
@@ -57,6 +58,7 @@ Feature: Logging with Member
 	Scenario: Program Location Management page - member
 		Given user logs in as "Cucumber Member"
 		And user selects "Program Management" in navigation
+		And user selects "Locations" tab
 		Then user can not see "Edit" link 
 		And user can not see "Deactivate" link
 		Then user can not see 'New Location' button in Program Management page

--- a/src/features/ProgramManagement.feature
+++ b/src/features/ProgramManagement.feature
@@ -292,7 +292,7 @@ Feature: Program Management (15)
 		Then user can see "Home" in navigation
 		Then user can see "Germplasm" in navigation
 		Then user can see "Ontology" in navigation
-		Then user can see "Program Management" in navigation
+		Then user can see "Program Administration" in navigation
 		Then user can see "BrAPI" in navigation
 		Then user can see "Jobs" in navigation
 		Then user can see "Experiments & Observations" in navigation

--- a/src/features/ProgramManagementLocationBreeder.feature
+++ b/src/features/ProgramManagementLocationBreeder.feature
@@ -4,6 +4,7 @@ Feature: Program Location Management
 		Given user logs in as "Cucumber Breeder"
 		When user selects "Snacks" on program-selection page
 		And user selects "Program Management" in navigation
+		And user selects "Locations" tab
 
 	@BI-905
 	Scenario: Program Location Management page - admin

--- a/src/features/ProgramManagementLocationBreeder.feature
+++ b/src/features/ProgramManagementLocationBreeder.feature
@@ -3,7 +3,7 @@ Feature: Program Location Management
 	Background: Required Setup
 		Given user logs in as "Cucumber Breeder"
 		When user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Locations" tab
 
 	@BI-905

--- a/src/features/SmokeTests.feature
+++ b/src/features/SmokeTests.feature
@@ -14,7 +14,7 @@ Feature: Smoke Tests (11)
 	Scenario Outline: New Program User
 		Given user logs in as "Cucumber Breeder"
 		When user selects "Snacks" on program-selection page
-		When user selects "Program Management" in navigation
+		When user selects "Program Administration" in navigation
 		When user selects "Users" tab
 		When user clicks 'New User' button
 		When user sets "<Name>" in Name field of User
@@ -35,7 +35,7 @@ Feature: Smoke Tests (11)
 	Scenario: Check Users page
 		Given user logs in as "Cucumber Breeder"
 		When user selects "Snacks" on program-selection page
-		When user selects "Program Management" in navigation
+		When user selects "Program Administration" in navigation
 		When user selects "Users" tab
 		Then user can see "Name" column in Users
 		Then user can see "Email" column in Users
@@ -50,7 +50,7 @@ Feature: Smoke Tests (11)
 	Scenario Outline: Program Location Management page
 		Given user logs in as "Cucumber Breeder"
 		When user selects "Snacks" on program-selection page
-		When user selects "Program Management" in navigation
+		When user selects "Program Administration" in navigation
 		When user selects "Locations" tab
 		When user selects 'New Location' button in Program Management page
 		When user sets "<location name>" in Name field in Program Management page
@@ -72,7 +72,7 @@ Feature: Smoke Tests (11)
 	Scenario: Program Location Management page
 		Given user logs in as "sysad"
 		When user selects "Snacks" on program-selection page
-		When user selects "Program Management" in navigation
+		When user selects "Program Administration" in navigation
 		When user selects "Locations" tab
 		When user selects 'New Location' button in Program Management page
 		When user sets "<location name>" in Name field in Program Management page

--- a/src/features/UserManagementBreeder.feature
+++ b/src/features/UserManagementBreeder.feature
@@ -7,14 +7,14 @@ Feature: Breeder User Management
 		When user selects "Snacks" on program-selection page
 		Then user can see "Home" in navigation
 		And user can see "Ontology" in navigation
-		And user can see "Program Management" in navigation
+		And user can see "Program Administration" in navigation
 
 	@BI-864
 	@BI-888
 	Scenario: Program Users Table
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		Then user can see Program User Management page
 		And user can see Users page
@@ -37,7 +37,7 @@ Feature: Breeder User Management
 	Scenario: User Management page
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		Then user can see Program User Management page
 
@@ -45,7 +45,7 @@ Feature: Breeder User Management
 	Scenario: System Admin and Program Member - Program User Management
 		Given user logs in as "sysad"
 		And user selects "Trail Mix" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		Then user can see page of Users
 		And user can see table header contains
@@ -57,7 +57,7 @@ Feature: Breeder User Management
 	Scenario: ???
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		Then user can see Program User Management page
 
@@ -65,7 +65,7 @@ Feature: Breeder User Management
 	Scenario: New User form - enter nothing and select Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		When user selects New User button
 		And user selects Save button
@@ -78,7 +78,7 @@ Feature: Breeder User Management
 	Scenario: New User form - enter name only - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		When user selects New User button
 		And user sets "Tester Breeder" in Name field
@@ -90,7 +90,7 @@ Feature: Breeder User Management
 	Scenario: New Program User form - enter name and email only - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		And user selects New User button
 		And user sets "Tester Breeder" in Name field
@@ -103,7 +103,7 @@ Feature: Breeder User Management
 	Scenario: New User form - enter all required, valid fields - Cancel
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		And user selects New User button
 		And user sets "Tester Breeder" in Name field
@@ -117,7 +117,7 @@ Feature: Breeder User Management
 	Scenario: New User form - enter all required, valid fields - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		When user creates a new user
 			| Name   | Email                | Role    |
@@ -128,7 +128,7 @@ Feature: Breeder User Management
 	Scenario: NEW Program User form - enter invalid email address - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		And user selects New User button
 		And user sets "Tester Breeder" in Name field
@@ -142,7 +142,7 @@ Feature: Breeder User Management
 	Scenario: NEW User form - enter existing email address - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		When user selects New User button
 		And user sets "TestNewUser" in Name field
@@ -156,7 +156,7 @@ Feature: Breeder User Management
 	Scenario: Edit Form elements
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		When user creates a new user
 			| Name   | Email                | Role    |
@@ -170,7 +170,7 @@ Feature: Breeder User Management
 	Scenario: Edit Form - change role - Cancel
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		When user creates a new user
 			| Name   | Email                | Role    |
@@ -183,7 +183,7 @@ Feature: Breeder User Management
 	Scenario: Edit Form - change role - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		When user creates a new user
 			| Name   | Email                | Role    |
@@ -197,7 +197,7 @@ Feature: Breeder User Management
 	Scenario Outline: Deactivate link - modal
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		And user creates a new user
 			| Name  | Email                | Role    |
@@ -219,7 +219,7 @@ Feature: Breeder User Management
 	Scenario: Deactivate link - Cancel
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		And user creates a new user
 			| Name   | Email                | Role    |
@@ -233,7 +233,7 @@ Feature: Breeder User Management
 	Scenario: Deactivate link - Yes, deactivate
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		And user creates a new user
 			| Name   | Email                | Role    |
@@ -246,7 +246,7 @@ Feature: Breeder User Management
 	Scenario: admin editing self - Program User management
 		Given user logs in as "sysad"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		When user selects "Edit" of Name "Christian"
 		When user selects "member" in Role dropdown
@@ -261,7 +261,7 @@ Feature: Breeder User Management
 	Scenario: breeder with no admin role editing self - Program User management
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
-		And user selects "Program Management" in navigation
+		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		When user selects "Edit" of Name "Cucumber Breeder"
 		When user selects "member" in Role dropdown

--- a/src/page_objects/page.js
+++ b/src/page_objects/page.js
@@ -156,7 +156,7 @@ module.exports = {
       locateStrategy: "xpath",
     },
     programManagementHeader: {
-      selector: "//section/div/h1[normalize-space(.)='Program Management']",
+      selector: "//section/div/h1[normalize-space(.)='Program Administration']",
       locateStrategy: "xpath",
     },
 
@@ -207,7 +207,7 @@ module.exports = {
         },
 
         programManagementLink: {
-          selector: ".//a[normalize-space()='Program Management']",
+          selector: ".//a[normalize-space()='Program Administration']",
           locateStrategy: "xpath",
         },
       },

--- a/src/page_objects/page.js
+++ b/src/page_objects/page.js
@@ -364,8 +364,8 @@ module.exports = {
           selector: ".//li/a[normalize-space(.)='Users']",
           locateStrategy: "xpath",
         },
-        configurationLink: {
-          selector: ".//li/a[normalize-space(.)='Configuration']",
+        ontologySharingLink: {
+          selector: ".//li/a[normalize-space(.)='Ontology Sharing']",
           locateStrategy: "xpath",
         },
         nameIsRequiredText: {
@@ -427,9 +427,9 @@ module.exports = {
         message: { selector: ".//section//section", locateStrategy: "xpath" },
       },
     },
-    //Program Management Configuration
-    configurationForm: {
-      selector: "#program-configuration",
+    //Program Management Ontology Sharing
+    ontologySharingForm: {
+      selector: "#ontology-sharing",
       elements: {
         sharedOntologySection:"#shared-ontology-section",
         header: "#shared-ontology-section > h2",

--- a/src/step_definitions/programManagementSteps.js
+++ b/src/step_definitions/programManagementSteps.js
@@ -454,9 +454,9 @@ Then(/^user can see 'Users' tab in Program Management page$/, async () => {
 });
 
 Then(
-  /^user can see 'Configuration' tab on Program Management page$/,
+  /^user can see 'Ontology Sharing' tab on Program Management page$/,
   async () => {
-    await page.section.programManagement.assert.visible("@configurationLink");
+    await page.section.programManagement.assert.visible("@ontologySharingLink");
   }
 );
 
@@ -637,8 +637,8 @@ When(
       case "Users":
         await page.section.programManagement.click("@usersLink");
         break;
-      case "Configuration":
-        await page.section.programManagement.click("@configurationLink");
+      case "Ontology Sharing":
+        await page.section.programManagement.click("@ontologySharingLink");
         break;
       default:
         throw new Error(`Unexpected ${args1} tab name.`);
@@ -647,18 +647,18 @@ When(
 );
 
 Then(
-  /^user can see Configuration on Program Management page$/,
+  /^user can see Ontology Sharing on Program Management page$/,
   async function () {
-    await page.expect.section("@configurationForm").visible;
+    await page.expect.section("@ontologySharingForm").visible;
   }
 );
 
 Then(
-  /^user can see "([^"]*)" section on Configuration tab on Program Management page$/,
+  /^user can see "([^"]*)" section on Ontology Sharing tab on Program Management page$/,
   async function (args1) {
     switch (args1) {
       case "Shared Ontology":
-        await page.section.configurationForm.assert.visible(
+        await page.section.ontologySharingForm.assert.visible(
           "@sharedOntologySection"
         );
         break;
@@ -669,12 +669,12 @@ Then(
 );
 
 Then(
-  /^user can see "([^"]*)" message on Configuration tab on Program Management page$/,
+  /^user can see "([^"]*)" message on Ontology Sharing tab on Program Management page$/,
   async function (args1) {
     if (args1.includes("*")) {
       args1 = program.Name;
     }
-    await page.section.configurationForm.assert.containsText(
+    await page.section.ontologySharingForm.assert.containsText(
       "@notSharedMessage",
       args1
     );
@@ -684,7 +684,7 @@ Then(
 When(
   /^user selects 'Share Ontology' button on Program Management page$/,
   async function () {
-    await page.section.configurationForm.click("@shareOntologyButton");
+    await page.section.ontologySharingForm.click("@shareOntologyButton");
   }
 );
 

--- a/src/step_definitions/programManagementSteps.js
+++ b/src/step_definitions/programManagementSteps.js
@@ -11,7 +11,7 @@ const { Sign } = require("crypto");
 
 Then(/^user can see Program User Management page$/, async () => {
   await page.assert.visible({
-    selector: "//*[@id='main']//h1[contains(text(),'Program Management')]",
+    selector: "//*[@id='main']//h1[contains(text(),'Program Administration')]",
     locateStrategy: "xpath",
   });
 });

--- a/src/step_definitions/steps.js
+++ b/src/step_definitions/steps.js
@@ -720,7 +720,7 @@ Then(/^user can see "([^"]*)" in navigation$/, async (args1) => {
     case "Ontology":
       await page.assert.visible("@ontologyMenu");
       break;
-    case "Program Management":
+    case "Program Administration":
       await page.assert.visible("@programManagementMenu");
       break;
     case "BrAPI":


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1651

Updated selectors to reference change of "Configuration" tab to "Ontology Sharing".  Also updated selectors to recognize that the "Users" tab is now first on the Program Administration page.


# Dependencies


# Testing
https://github.com/Breeding-Insight/taf/actions/runs/4265460787


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
