### PR TITLE
 [BI-1707] - renamed feature, page definitions and steps

### DIFF
--- a/src/features/Configuration.feature
+++ b/src/features/Configuration.feature
@@ -1,12 +1,12 @@
 
-Feature: Ontology Sharing
+Feature: Configuration
 
     Background: Required Setup
         Given user logs in as "sysad"
         And user selects "System Administration" on program-selection page
 
     @BI-1502
-    Scenario Outline: Ontology Sharing as a sub-menu
+    Scenario Outline: Configuration as a sub-menu
         When user is on the program-management page
         #Create a new program
         When user selects 'New Program' button in Programs page
@@ -31,11 +31,11 @@ Feature: Ontology Sharing
         When user logs in as "Cucumber Breeder"
         When user selects "Snacks" on program-selection page
         When user selects "Program Administration" in navigation
-        Then user can see 'Ontology Sharing' tab on Program Management page
-        When user selects "Ontology Sharing" tab on Program Management page
-        Then user can see Ontology Sharing on Program Management page
-        Then user can see "Shared Ontology" section on Ontology Sharing tab on Program Management page
-        Then user can see "Snacks is not currently sharing their ontology with other programs." message on Ontology Sharing tab on Program Management page
+        Then user can see 'Configuration' tab on Program Management page
+        When user selects "Configuration" tab on Program Management page
+        Then user can see Configuration on Program Management page
+        Then user can see "Shared Ontology" section on Configuration tab on Program Management page
+        Then user can see "Snacks is not currently sharing their ontology with other programs." message on Configuration tab on Program Management page
         When user selects Share Ontology button of Shared Ontology on Program Management page
         When user can see the 'Manage  Share Ontology' in Managed Shared Ontlogy page
         Then user can see "<ProgramName>" checkbox in Managed Shared Ontlogy page
@@ -47,10 +47,10 @@ Feature: Ontology Sharing
         When user navigates to Program Selection page
         When user selects "<ProgramName>" on program-selection page
         When user selects "Program Administration" in navigation
-        Then user can see 'Ontology Sharing' tab on Program Management page
-        When user selects "Ontology Sharing" tab on Program Management page
-        Then user can see Ontology Sharing on Program Management page
-        Then user can see "Shared Ontology" section on Ontology Sharing tab on Program Management page
+        Then user can see 'Configuration' tab on Program Management page
+        When user selects "Configuration" tab on Program Management page
+        Then user can see Configuration on Program Management page
+        Then user can see "Shared Ontology" section on Configuration tab on Program Management page
         When user selects "Snacks" in Choose ontology to subscribe to dropdown on Program Management page
         When user selects Save button of Subscribe to Shared Ontology on Program Management page
         When user pause for "5" seconds
@@ -59,15 +59,15 @@ Feature: Ontology Sharing
         When user navigates to Program Selection page
         When user selects "Snacks" on program-selection page
         When user selects "Program Administration" in navigation
-        Then user can see 'Ontology Sharing' tab on Program Management page
-        When user selects "Ontology Sharing" tab on Program Management page
-        Then user can see Ontology Sharing on Program Management page
-        Then user can see "Shared Ontology" section on Ontology Sharing tab on Program Management page
+        Then user can see 'Configuration' tab on Program Management page
+        When user selects "Configuration" tab on Program Management page
+        Then user can see Configuration on Program Management page
+        Then user can see "Shared Ontology" section on Configuration tab on Program Management page
         Then user can see "<ProgramName>" is currently shared and accepted message
         When user selects Share Ontology button of Shared Ontology on Program Management page
         When user selects "<ProgramName>" checkbox in Managed Shared Ontlogy page
         When user selects "Save" button in Managed Shared Ontlogy page
-        Then user can see "Snacks is not currently sharing their ontology with other programs." message on Ontology Sharing tab on Program Management page
+        Then user can see "Snacks is not currently sharing their ontology with other programs." message on Configuration tab on Program Management page
     
         Examples:
             | ProgramName | Key | Species |

--- a/src/page_objects/page.js
+++ b/src/page_objects/page.js
@@ -364,8 +364,8 @@ module.exports = {
           selector: ".//li/a[normalize-space(.)='Users']",
           locateStrategy: "xpath",
         },
-        ontologySharingLink: {
-          selector: ".//li/a[normalize-space(.)='Ontology Sharing']",
+        programConfigurationLink: {
+          selector: ".//li/a[normalize-space(.)='Configuration']",
           locateStrategy: "xpath",
         },
         nameIsRequiredText: {
@@ -427,9 +427,9 @@ module.exports = {
         message: { selector: ".//section//section", locateStrategy: "xpath" },
       },
     },
-    //Program Management Ontology Sharing
-    ontologySharingForm: {
-      selector: "#ontology-sharing",
+    //Program Management Configuration
+    programConfigurationForm: {
+      selector: "#program-configuration",
       elements: {
         sharedOntologySection:"#shared-ontology-section",
         header: "#shared-ontology-section > h2",

--- a/src/step_definitions/programManagementSteps.js
+++ b/src/step_definitions/programManagementSteps.js
@@ -454,9 +454,9 @@ Then(/^user can see 'Users' tab in Program Management page$/, async () => {
 });
 
 Then(
-  /^user can see 'Ontology Sharing' tab on Program Management page$/,
+  /^user can see 'Configuration' tab on Program Management page$/,
   async () => {
-    await page.section.programManagement.assert.visible("@ontologySharingLink");
+    await page.section.programManagement.assert.visible("@programConfigurationLink");
   }
 );
 
@@ -637,8 +637,8 @@ When(
       case "Users":
         await page.section.programManagement.click("@usersLink");
         break;
-      case "Ontology Sharing":
-        await page.section.programManagement.click("@ontologySharingLink");
+      case "Configuration":
+        await page.section.programManagement.click("@programConfigurationLink");
         break;
       default:
         throw new Error(`Unexpected ${args1} tab name.`);
@@ -647,18 +647,18 @@ When(
 );
 
 Then(
-  /^user can see Ontology Sharing on Program Management page$/,
+  /^user can see Configuration on Program Management page$/,
   async function () {
-    await page.expect.section("@ontologySharingForm").visible;
+    await page.expect.section("@programConfigurationForm").visible;
   }
 );
 
 Then(
-  /^user can see "([^"]*)" section on Ontology Sharing tab on Program Management page$/,
+  /^user can see "([^"]*)" section on Configuration tab on Program Management page$/,
   async function (args1) {
     switch (args1) {
       case "Shared Ontology":
-        await page.section.ontologySharingForm.assert.visible(
+        await page.section.programConfigurationForm.assert.visible(
           "@sharedOntologySection"
         );
         break;
@@ -669,12 +669,12 @@ Then(
 );
 
 Then(
-  /^user can see "([^"]*)" message on Ontology Sharing tab on Program Management page$/,
+  /^user can see "([^"]*)" message on Configuration tab on Program Management page$/,
   async function (args1) {
     if (args1.includes("*")) {
       args1 = program.Name;
     }
-    await page.section.ontologySharingForm.assert.containsText(
+    await page.section.programConfigurationForm.assert.containsText(
       "@notSharedMessage",
       args1
     );
@@ -684,7 +684,7 @@ Then(
 When(
   /^user selects 'Share Ontology' button on Program Management page$/,
   async function () {
-    await page.section.ontologySharingForm.click("@shareOntologyButton");
+    await page.section.programConfigurationForm.click("@shareOntologyButton");
   }
 );
 


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1707

Updated TAF to account for renaming Ontology Sharing tab to Configuration in Program Management in bi-web. 


# Dependencies
Corresponds to https://github.com/Breeding-Insight/bi-web/pull/308.


# Testing
_Please include a link to a successful run of TAF for this change_


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
