### PR TITLE
BI-1799 - removed click Show All on germplasm page

### DIFF
--- a/src/features/GermplasmImportTable.feature
+++ b/src/features/GermplasmImportTable.feature
@@ -53,7 +53,6 @@ Feature: Germplasm Import Table
         Given user logs in as "Cucumber Breeder"
         When user selects "P*" on program-selection page
         And user selects "Germplasm" in navigation
-        When user clicks Show All button
         Then user can see Female Parent GID value is a link
         Then user can see Male Parent GID value is a link
         When user selects "3" row Female Parent GID


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1799

Because the Show All button has been removed from the Germplasm page, I updated the TAF scenario that tries to click it.

# Dependencies
The code changes are in bi-web, https://github.com/Breeding-Insight/bi-web/pull/323.


# Testing
https://github.com/Breeding-Insight/taf/actions/runs/5931166625


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
