### PR TITLE
Fix for BI-1776 - added pause

### DIFF
--- a/src/features/ExperimentsImport.feature
+++ b/src/features/ExperimentsImport.feature
@@ -202,6 +202,7 @@ Feature: Experiments & Observations
         When user selects 'Import' button
         When user pause for "10" seconds
         And user selects "Confirm" button
+        When user pause for "10" seconds
         And user uploads Experiments & Observations "EXP.csv" file
         When user selects 'Import' button
         Then user can see "Import Experiments & Observations" preview table


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1776

This section

```
...
And user uploads Experiments & Observations "EXP.csv" file
When user selects 'Import' button
When user pause for "10" seconds
And user selects "Confirm" button
And user uploads Experiments & Observations "EXP.csv" file
...
```
was failing in CI because the `And user selects "Confirm" button` requires a bit of processing time before the upload button becomes available for the next line.

I added a 10 second pause.


# Testing
https://github.com/Breeding-Insight/taf/actions/runs/5895842611 - This run failed, see [my comment below](https://github.com/Breeding-Insight/taf/pull/122#issuecomment-1688042033) for context.


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
