### PR TITLE
BI-1958 - Removed germplasm images and attributes tab checks

### DIFF
--- a/src/features/GermplasmImportTable.feature
+++ b/src/features/GermplasmImportTable.feature
@@ -44,9 +44,7 @@ Feature: Germplasm Import Table
         Then user can see details on Germplasm details page
             | Preferred Name | GID | Breeding Method | Source | Pedigree                | Pedigree GID | Synonyms | External UID | User             | Creation Date |
             | Germplas124    | 3   | Backcross       | Cross  | Germplas123/Germplas123 | 2 / 2        | Germ2    |              | Cucumber Breeder |               |
-        Then user can see "Images" tab of Germplasm details page
         Then user can see "Pedigrees" tab of Germplasm details page
-        Then user can see "Attributes" tab of Germplasm details page
 
     @BI-1514
     Scenario: GIDs clickable Link


### PR DESCRIPTION
# Description
**Story:** [BI-1958](https://breedinginsight.atlassian.net/browse/BI-1958?atlOrigin=eyJpIjoiY2M5MDhlM2IzYWVmNGY5NDgyYThiZDFhNzNjZjAxY2IiLCJwIjoiaiJ9)

- Removed checks for germplasm images and attributes tabs.

# Dependencies
- bi-web develop

# Testing
https://github.com/Breeding-Insight/taf/actions/runs/6803253188


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation


[BI-1958]: https://breedinginsight.atlassian.net/browse/BI-1958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ