### PR TITLE
[BI-1915] Export Ontology File

### DIFF
--- a/src/features/ExperimentsImport.feature
+++ b/src/features/ExperimentsImport.feature
@@ -36,7 +36,8 @@ Feature: Experiments & Observations
         When user sets "GermplasmSort" in List Description field of import page
         And user selects "Confirm" button
         When user selects "Ontology" in navigation
-        When user selects "Import Batch File" button
+        When user selects "Manage Ontology" button
+        When user selects "Import file" link
         And user uploads Ontology "test01-ontology.xls" file
         When user selects 'Import' button
         And user selects "Confirm" button
@@ -87,7 +88,8 @@ Feature: Experiments & Observations
         When user sets "GermplasmSort" in List Description field of import page
         And user selects "Confirm" button
         When user selects "Ontology" in navigation
-        When user selects "Import Batch File" button
+        When user selects "Manage Ontology" button
+        When user selects "Import file" link
         And user uploads Ontology "test01-ontology.xls" file
         When user selects 'Import' button
         And user selects "Confirm" button
@@ -143,7 +145,8 @@ Feature: Experiments & Observations
         When user sets "GermplasmSort" in List Description field of import page
         And user selects "Confirm" button
         When user selects "Ontology" in navigation
-        When user selects "Import Batch File" button
+        When user selects "Manage Ontology" button
+        When user selects "Import file" link
         And user uploads Ontology "test01-ontology.xls" file
         When user selects 'Import' button
         And user selects "Confirm" button
@@ -191,7 +194,8 @@ Feature: Experiments & Observations
         When user sets "GermplasmSort" in List Description field of import page
         And user selects "Confirm" button
         When user selects "Ontology" in navigation
-        When user selects "Import Batch File" button
+        When user selects "Manage Ontology" button
+        When user selects "Import file" link
         And user uploads Ontology "test01-ontology.xls" file
         When user selects 'Import' button
         And user selects "Confirm" button

--- a/src/features/GermplasmTable.feature
+++ b/src/features/GermplasmTable.feature
@@ -46,7 +46,8 @@ Feature: Germplasm table loading message
         Then user can not see loading wheel message on Germplasm page
         And user selects "Import Data" in navigation
         When user selects "Ontology" in navigation
-        When user selects "Import Batch File" button
+        When user selects "Manage Ontology" button
+        When user selects "Import file" link
         And user uploads Ontology "test01-ontology.xls" file
         When user selects 'Import' button
         And user selects "Confirm" button
@@ -92,7 +93,8 @@ Feature: Germplasm table loading message
         And user selects "Confirm" button
         And user selects "Import Data" in navigation
         When user selects "Ontology" in navigation
-        When user selects "Import Batch File" button
+        When user selects "Manage Ontology" button
+        When user selects "Import file" link
         And user uploads Ontology "test01-ontology.xls" file
         When user selects 'Import' button
         And user selects "Confirm" button

--- a/src/features/OntologyImportPreview.feature
+++ b/src/features/OntologyImportPreview.feature
@@ -35,7 +35,8 @@ Feature: Ontology Import Preview
         When user sets "GermplasmSort" in List Description field of import page
         And user selects "Confirm" button
         When user selects "Ontology" in navigation
-        When user selects "Import Batch File" button
+        When user selects "Manage Ontology" button
+        When user selects "Import file" link
         And user uploads Ontology "test01-ontology.xls" file
         When user selects 'Import' button
         When user selects 'Show details' button of "Blackberry" on Ontology Import page

--- a/src/step_definitions/steps.js
+++ b/src/step_definitions/steps.js
@@ -865,6 +865,16 @@ When(/^user selects "([^"]*)" button$/, async (args1) => {
   await page.click(selector);
 });
 
+When(/^user selects "([^"]*)" link$/, async (args1) => {
+  await page.pause(1000);
+  const selector = {
+    selector: `//a[starts-with(normalize-space(.),'${args1}')]`,
+    locateStrategy: "xpath",
+  };
+  await page.waitForElementVisible(selector);
+  await page.click(selector);
+});
+
 Then(/^user can see "([^"]*)" button$/, async (args1) => {
   await page.assert.visible({
     selector: `//button[contains(normalize-space(.),'${args1}')]`,
@@ -935,6 +945,7 @@ When(/^user selects 'Yes, abort' button$/, async () => {
     locateStrategy: "xpath",
   });
 });
+
 
 Then(/^user can see Ontology table$/, async () => {
   await page.assert.visible("#ontologyTableLabel");


### PR DESCRIPTION
[BI-19115](https://breedinginsight.atlassian.net/browse/BI-1915) Export Ontology File

# Description
On the _Ontology_ page the `Import Batch File` button was removed and replaced with `Manage Ontology` pull-down button.  An option under that pull-down is `Import file` option

Several scenarios needed to be updated to reflect that change.  Namely:

- Feature: Experiments & Observations
 . @BI-1598
 . @BI-1603
 . @BI-1775
 . @BI-1776
- Feature: Germplasm table loading message
 . @BI-1600
 . @BI-1601
- Feature: Ontology Import Preview
 . @BI-1599


# Dependencies
bi-web: feature/Bi-1915
bi-api: feature/Bi-1915


# Testing
Compare the [TAF run before this change](https://github.com/Breeding-Insight/taf/actions/runs/6801721354) and the [TAF run after this change](https://github.com/Breeding-Insight/taf/actions/runs/6826483479).


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
