### PR TITLE
[BI-1960] Exp import proceeds with multiple exp names & error message improvement

### DIFF
--- a/src/features/ExperimentsImport.feature
+++ b/src/features/ExperimentsImport.feature
@@ -156,7 +156,7 @@ Feature: Experiments & Observations
         And user uploads Experiments & Observations "EXPBadTitle.csv" file
         When user selects 'Import' button
         When user pause for "10" seconds
-        Then user can see banner appears with an error message "Fix Invalid Fields"
+        Then user can see banner appears with an error message "File contains more than one Experiment title"
         Examples:
             | ProgramName | Key | Species |
             | A*          | T*  | Grape   |

--- a/src/features/ExperimentsImport.feature
+++ b/src/features/ExperimentsImport.feature
@@ -156,7 +156,7 @@ Feature: Experiments & Observations
         And user uploads Experiments & Observations "EXPBadTitle.csv" file
         When user selects 'Import' button
         When user pause for "10" seconds
-        Then user can see banner appears with an error message "File contains more than one Experiment title"
+        Then user can see banner appears with an error message "File contains more than one Experiment Title"
         Examples:
             | ProgramName | Key | Species |
             | A*          | T*  | Grape   |

--- a/src/features/ExperimentsImport.feature
+++ b/src/features/ExperimentsImport.feature
@@ -259,6 +259,7 @@ Feature: Experiments & Observations
         When user pause for "10" seconds
         And user uploads Experiments & Observations "EXP.csv" file
         When user selects 'Import' button
+        When user pause for "10" seconds
         Then user can see "Import Experiments & Observations" preview table
         Then user can see "User: Cucumber Breeder" in preview table
         Then user can see "Creation Date: @TODAY" in preview table

--- a/src/features/ExperimentsImport.feature
+++ b/src/features/ExperimentsImport.feature
@@ -110,6 +110,57 @@ Feature: Experiments & Observations
             | ProgramName | Key | Species |
             | A*          | T*  | Grape   |
 
+    @BI-1960
+    Scenario Outline: Error reporting Multiple Experiment Titles
+        #Create a new program
+        When user selects 'New Program' button in Programs page
+        When user sets "<ProgramName>" in Program Name field in Programs page
+        When user selects "<Species>" in Species dropdown in Programs page
+        When user sets "<Key>" in Program Key field in Programs page
+        When user selects 'Save' button in Programs page
+        When user pause for "10" seconds
+        When user navigates to Program Selection page
+        When user selects "<ProgramName>" on program-selection page
+        When user selects "Program Administration" in navigation
+        When user selects "Users" tab
+        When user clicks 'New User' button
+        When user sets "Cucumber Breeder" in Name field of User
+        When user sets "cucumberbreeder@mailinator.com" in Email field of User
+        When user sets "breeder" in Role dropdown of User
+        When user click 'Save' button in User
+        When user pause for "10" seconds
+        When user close notification pop-up
+        When user logs out
+        Given user logs in as "Cucumber Breeder"
+        When user selects "<ProgramName>" on program-selection page
+        And user selects "Import Data" in navigation
+        And user uploads Germplasm "GermplasmBad.xlsx" file
+        And user selects 'Import' button
+        When user pause for "10" seconds
+        Then user can see "Breeding Method" in row "1" as "Field" column on Germplasm Lists
+        Then user can see "Source" in row "2" as "Field" column on Germplasm Lists
+        And user uploads Germplasm "GermplasmSample.xlsx" file
+        And user selects 'Import' button
+        When user sets "GermplasmSort" in List Name field of import page
+        When user sets "GermplasmSort" in List Description field of import page
+        And user selects "Confirm" button
+        When user selects "Ontology" in navigation
+        When user selects "Manage Ontology" button
+        When user selects "Import file" link
+        And user uploads Ontology "test01-ontology.xls" file
+        When user selects 'Import' button
+        And user selects "Confirm" button
+        When user pause for "10" seconds
+        When user selects "Experiments & Observations" in navigation
+        When user selects "Import Experiments & Observations" button
+        And user uploads Experiments & Observations "EXPBadTitle.csv" file
+        When user selects 'Import' button
+        When user pause for "10" seconds
+        Then user can see banner appears with an error message "Fix Invalid Fields"
+        Examples:
+            | ProgramName | Key | Species |
+            | A*          | T*  | Grape   |
+
     @BI-1775
     Scenario Outline: Error reporting Text to Table
         #Create a new program
@@ -156,10 +207,9 @@ Feature: Experiments & Observations
         And user uploads Experiments & Observations "EXPBad.csv" file
         When user selects 'Import' button
         When user pause for "10" seconds
-        Then user can see "Exp Title" in row "1" as "Field" column on Experiment and Observation Import page
-        Then user can see "Germplasm GID" in row "2" as "Field" column on Experiment and Observation Import page
-        Then user can see "Env Year" in row "3" as "Field" column on Experiment and Observation Import page
-        Then user can see "Env" in row "4" as "Field" column on Experiment and Observation Import page
+        Then user can see "Germplasm GID" in row "1" as "Field" column on Experiment and Observation Import page
+        Then user can see "Env Year" in row "2" as "Field" column on Experiment and Observation Import page
+        Then user can see "Env" in row "3" as "Field" column on Experiment and Observation Import page
 
         Examples:
             | ProgramName | Key | Species |

--- a/src/files/ExperimentsImport/EXP.csv
+++ b/src/files/ExperimentsImport/EXP.csv
@@ -1,5 +1,5 @@
 Germplasm Name,Germplasm GID,Test (T) or Check (C),Exp Title ,Exp Description,Exp Unit,Exp Type,Env,Env Location,Env Year,Exp Unit ID,Exp Replicate #,Exp Block #,Row,Column,Treatment Factors,ObsUnitID
-Germplas127,1,C,New Trial DRP53,A new trial DRP115,plot,phenotyping,New Study 15,New Location DRP6,2000,9390,1,2,4,5,Jam application,
-Germplas128,2,C,New Trial DRP54,A new trial DRP116,plot,phenotyping,New Study 16,New Location DRP7,2000,9391,1,2,4,5,Jam application,
-Germplas129,3,C,New Trial DRP55,A new trial DRP117,plot,phenotyping,New Study 17,New Location DRP8,2000,9392,1,2,4,5,Jam application,
-Germplas130,4,C,New Trial DRP56,A new trial DRP118,plot,phenotyping,New Study 18,New Location DRP9,2000,9393,1,2,4,5,Jam application,
+Germplas127,1,C,New Trial DRP,A new trial DRP,plot,phenotyping,New Study 15,New Location DRP6,2000,9390,1,2,4,5,Jam application,
+Germplas128,2,C,New Trial DRP,A new trial DRP,plot,phenotyping,New Study 16,New Location DRP7,2000,9391,1,2,4,5,Jam application,
+Germplas129,3,C,New Trial DRP,A new trial DRP,plot,phenotyping,New Study 17,New Location DRP8,2000,9392,1,2,4,5,Jam application,
+Germplas130,4,C,New Trial DRP,A new trial DRP,plot,phenotyping,New Study 18,New Location DRP9,2000,9393,1,2,4,5,Jam application,

--- a/src/files/ExperimentsImport/EXPBad.csv
+++ b/src/files/ExperimentsImport/EXPBad.csv
@@ -1,5 +1,5 @@
 Germplasm Name,Germplasm GID,Test (T) or Check (C),Exp Title ,Exp Description,Exp Unit,Exp Type,Env,Env Location,Env Year,Exp Unit ID,Exp Replicate #,Exp Block #,Row,Column,Treatment Factors,ObsUnitID
 Germplas140,1,C,New Trial DRP,A new trial DRP,plott,phenotyping,New Study 15,New Location DRP6,2000,9390,1,2,4,5,Jam application,
-Germplas141,2,C,,A new trial DRP,plot,phenotyping,New Study 16,New Location DRP7,2000,9391,1,2,4,5,,
+Germplas141,2,C,New Trial DRP,A new trial DRP,plot,phenotyping,New Study 16,New Location DRP7,2000,9391,1,2,4,5,,
 Germplas142,,C,New Trial DRP,A new trial DRP,plot,phenotyping,New Study 17,New Location DRP8,,9392,1,2,4,5,Jam application,
 Germplas143,4,C,New Trial DRP,A new trial DRP,3,phenotyping,,New Location DRP9,2000,9393,1,2,4,5,Jam application,

--- a/src/files/ExperimentsImport/EXPBad.csv
+++ b/src/files/ExperimentsImport/EXPBad.csv
@@ -1,5 +1,5 @@
 Germplasm Name,Germplasm GID,Test (T) or Check (C),Exp Title ,Exp Description,Exp Unit,Exp Type,Env,Env Location,Env Year,Exp Unit ID,Exp Replicate #,Exp Block #,Row,Column,Treatment Factors,ObsUnitID
-Germplas140,1,C,New Trial DRP53,A new trial DRP115,plott,phenotyping,New Study 15,New Location DRP6,2000,9390,1,2,4,5,Jam application,
-Germplas141,2,C,,A new trial DRP116,plot,phenotyping,New Study 16,New Location DRP7,2000,9391,1,2,4,5,,
-Germplas142,,C,New Trial DRP55,A new trial DRP117,plot,phenotyping,New Study 17,New Location DRP8,,9392,1,2,4,5,Jam application,
-Germplas143,4,C,New Trial DRP56,A new trial DRP118,3,phenotyping,,New Location DRP9,2000,9393,1,2,4,5,Jam application,
+Germplas140,1,C,New Trial DRP,A new trial DRP,plott,phenotyping,New Study 15,New Location DRP6,2000,9390,1,2,4,5,Jam application,
+Germplas141,2,C,,A new trial DRP,plot,phenotyping,New Study 16,New Location DRP7,2000,9391,1,2,4,5,,
+Germplas142,,C,New Trial DRP,A new trial DRP,plot,phenotyping,New Study 17,New Location DRP8,,9392,1,2,4,5,Jam application,
+Germplas143,4,C,New Trial DRP,A new trial DRP,3,phenotyping,,New Location DRP9,2000,9393,1,2,4,5,Jam application,

--- a/src/files/ExperimentsImport/EXPBadTitle.csv
+++ b/src/files/ExperimentsImport/EXPBadTitle.csv
@@ -1,0 +1,5 @@
+Germplasm Name,Germplasm GID,Test (T) or Check (C),Exp Title ,Exp Description,Exp Unit,Exp Type,Env,Env Location,Env Year,Exp Unit ID,Exp Replicate #,Exp Block #,Row,Column,Treatment Factors,ObsUnitID
+Germplas127,1,C,New Trial DRP,A new trial DRP,plot,phenotyping,New Study 15,New Location DRP6,2000,9390,1,2,4,5,Jam application,
+Germplas128,2,C,New Trial DRP 1,A new trial DRP,plot,phenotyping,New Study 16,New Location DRP7,2000,9391,1,2,4,5,Jam application,
+Germplas129,3,C,New Trial DRP,A new trial DRP,plot,phenotyping,New Study 17,New Location DRP8,2000,9392,1,2,4,5,Jam application,
+Germplas130,4,C,New Trial DRP,A new trial DRP,plot,phenotyping,New Study 18,New Location DRP9,2000,9393,1,2,4,5,Jam application,


### PR DESCRIPTION
# Description
**Story:** [BI-1960](https://breedinginsight.atlassian.net/browse/BI-1960)

Experiment import test files were updated so that only a single experiment name is used since changes to BI-1960 will return an error response if multiple exp names used.


# Dependencies
bi-api develop branch


# Testing
_Please include a link to a successful run of TAF for this change_


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation


[BI-1960]: https://breedinginsight.atlassian.net/browse/BI-1960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ