### PR TITLE
[BI-2037] - removed unnecessary workflow step

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -89,6 +89,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: Breeding-Insight/bi-docker-stack
+          submodules: recursive
           token: ${{ secrets.DOCKERPATH }}
           path: bi-docker-stack
 

--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -117,11 +117,6 @@ jobs:
         run: sleep 60s
         shell: bash
 
-      - name: Try setting up species again
-        run: |
-          docker cp bi-docker-stack/brapi-server/sql/species.sql bidb:/species.sql
-          docker exec bidb psql -U postgres -a -f species.sql -d postgres
-
       - name: Set up required bidb data for tests
         run: |
           docker cp populate-taf-data.sql bidb:/populate-taf-data.sql

--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -144,11 +144,6 @@ jobs:
         run: sleep 180s
         shell: bash
 
-      - name: Try setting up species again
-        run: |
-          docker cp bi-docker-stack/brapi-server/sql/species.sql bidb:/species.sql
-          docker exec bidb psql -U postgres -a -f species.sql -d postgres
-
       - name: Set up required bidb data for tests
         run: |
           docker cp populate-taf-data.sql bidb:/populate-taf-data.sql


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-2037

Removed unnecessary step from the GitHub actions workflow files. The brapi-server database should be seeded on container startup, the SQL files are bind-mounted into the container by the base docker-compose.yml file.

# Testing
Daily TAF workflow: https://github.com/Breeding-Insight/taf/actions/runs/7832681772
Custom TAF workflow: https://github.com/Breeding-Insight/taf/actions/runs/7832701300


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
