### PR TITLE
Bug/bi 2088

### DIFF
--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -3,24 +3,22 @@
 module.exports = {
   globals_path: "globals.js",
   page_objects_path: "./src/page_objects", //page_objects folder where selectors are saved
-  selenium: {
-    start_process: true,
-    port: 4444,
-    start_session: true,
-    server_path: require("selenium-server").path,
-
-    cli_args: {
-      "webdriver.gecko.driver": require("geckodriver").path,
-      "webdriver.chrome.driver": require("chromedriver").path,
-      //don't use the 64bit driver. it is really slow
-      "webdriver.edge.driver": "./src/driver/msedgedriver.exe",
-      "webdriver.ie.driver":
-        "./node_modules/iedriver/lib/iedriver/IEDriverServer.exe",
-    },
-  },
-
   test_settings: {
     default: {
+      webdriver: {
+        start_process: true,
+        server_path: require("chromedriver").path,
+        port: 4444,
+        cli_args: ['--port=4444']
+      },
+      desiredCapabilities: {
+        browserName: "chrome",
+        javascriptEnabled: true,
+        acceptSslCerts: true,
+        chromeOptions: {
+          args: ['headless', 'no-sandbox', 'disable-gpu']
+        }
+      },
       launch_url: "http://localhost",
       screenshots: {
         enabled: true,
@@ -46,13 +44,6 @@ module.exports = {
       },
     },
     chrome: {
-      desiredCapabilities: {
-        browserName: "chrome",
-        chromeOptions: {
-          args: ["headless", "no-sandbox", "disable-gpu"],
-          w3c: false,
-        },
-      },
     },
     edge: {
       selenium: {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "geckodriver": "^3.2.0",
     "iedriver": "^3.14.2",
     "mkdirp": "^1.0.4",
-    "nightwatch": "^1.6.3",
-    "nightwatch-api": "^3.0.1",
-    "selenium-server": "^3.141.59"
+    "nightwatch": "^1.7.13",
+    "nightwatch-api": "^3.0.1"
   }
 }


### PR DESCRIPTION
# Description
Remove selenium-server dependency.
Use webdriver directly to support running of chrome on a Mac.

# Dependencies
None

# Testing
https://github.com/Breeding-Insight/taf/actions/runs/8531294537/job/23370685582


# Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
