### PR TITLE
[BI-1692] - Change role names

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The implemented scenarios assume the following data is set up on BI:
 **Users**
 | Name | Email | System Role |
 | ------ | ------ | ------ |
-| Christian | christian@mailinator.com | admin |
+| Christian | christian@mailinator.com | System Administrator |
 | Cucumber Breeder | cucumberbreeder@mailinator.com | |
 | Cucumber Member | cucumbermember@mailinator.com| |
 | TrailMix Breeder | trailmix@mailinator.com | |
@@ -77,8 +77,8 @@ The implemented scenarios assume the following data is set up on BI:
 **Programs**
 | Name | Species | Users (role) |
 | ------ | ------ | ------ |
-| Snacks | Grape | Cucumber Breeder (breeder) <br> Cucumber Member (member) <br> Christian (breeder) |
-| Trail Mix | Grape | Cucumber Breeder (member) <br> TrailMix Breeder (breeder) <br> Christian (breeder) |
+| Snacks | Grape | Cucumber Breeder (Program Administrator) <br> Cucumber Member (Read Only) <br> Christian (Program Administrator) |
+| Trail Mix | Grape | Cucumber Breeder (Read Only) <br> TrailMix Breeder (Program Administrator) <br> Christian (Program Administrator) |
 
 **Automated Database Setup**
 

--- a/populate-taf-data.sql
+++ b/populate-taf-data.sql
@@ -27,7 +27,7 @@ VALUES
 ('0000-0002-7046-0251', 'TrailMix Breeder', 'trailmix@mailinator.com', by_user_id, by_user_id, true);
 
 INSERT INTO system_user_role (bi_user_id, system_role_id, created_by, updated_by) 
-SELECT bi_user.id, system_role.id, by_user_id, by_user_id FROM bi_user JOIN system_role ON bi_user.name = 'Christian' and system_role.domain = 'admin';
+SELECT bi_user.id, system_role.id, by_user_id, by_user_id FROM bi_user JOIN system_role ON bi_user.name = 'Christian' and system_role.domain = 'System Administrator';
 
 --Create program germplasm sequences
 create sequence tmtest_germplasm_sequence;
@@ -49,27 +49,27 @@ SELECT id, by_user_id, by_user_id FROM program WHERE name = 'Snacks';
 
 --Add Users To Programs
 INSERT INTO program_user_role (program_id, user_id, role_id, created_by, updated_by, active) 
-SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'Cucumber Breeder' and role.domain = 'breeder'
+SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'Cucumber Breeder' and role.domain = 'Program Administrator'
 JOIN program ON program.name = 'Snacks';
 
 INSERT INTO program_user_role (program_id, user_id, role_id, created_by, updated_by, active) 
-SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'Cucumber Breeder' and role.domain = 'member'
+SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'Cucumber Breeder' and role.domain = 'Read Only'
 JOIN program ON program.name = 'Trail Mix';
 
 INSERT INTO program_user_role (program_id, user_id, role_id, created_by, updated_by, active) 
-SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'Cucumber Member' and role.domain = 'member'
+SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'Cucumber Member' and role.domain = 'Read Only'
 JOIN program ON program.name = 'Snacks';
 
 INSERT INTO program_user_role (program_id, user_id, role_id, created_by, updated_by, active) 
-SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'TrailMix Breeder' and role.domain = 'breeder'
+SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'TrailMix Breeder' and role.domain = 'Program Administrator'
 JOIN program ON program.name = 'Trail Mix';
 
 INSERT INTO program_user_role (program_id, user_id, role_id, created_by, updated_by, active) 
-SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'Christian' and role.domain = 'breeder'
+SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'Christian' and role.domain = 'Program Administrator'
 JOIN program ON program.name = 'Snacks';
 
 INSERT INTO program_user_role (program_id, user_id, role_id, created_by, updated_by, active) 
-SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'Christian' and role.domain = 'breeder'
+SELECT program.id, bi_user.id, role.id, by_user_id, by_user_id, true FROM bi_user JOIN role ON bi_user.name = 'Christian' and role.domain = 'Program Administrator'
 JOIN program ON program.name = 'Trail Mix';
 
 INSERT INTO program_enabled_breeding_methods(breeding_method_id, program_id, created_by, created_at, updated_by, updated_at)

--- a/src/features/BreedingMethods.feature
+++ b/src/features/BreedingMethods.feature
@@ -19,7 +19,7 @@ Feature: Breeding Methods
     When user clicks 'New User' button
     When user sets "Christian" in Name field of User
     When user sets "christian@mailinator.com" in Email field of User
-    When user sets "breeder" in Role dropdown of User
+    When user sets "Program Administrator" in Role dropdown of User
     When user click 'Save' button in User
     And user pause for "5" seconds
     And user selects "Breeding Methods" tab
@@ -82,13 +82,13 @@ Feature: Breeding Methods
     When user clicks 'New User' button
     When user sets "Breeder" in Name field of User
     When user sets "cucumberbreeder@mailinator.com" in Email field of User
-    When user sets "breeder" in Role dropdown of User
+    When user sets "Program Administrator" in Role dropdown of User
     When user click 'Save' button in User
     And user pause for "5" seconds
     When user clicks 'New User' button
     When user sets "Breeder" in Name field of User
     When user sets "cucumbermember@mailinator.com" in Email field of User
-    When user sets "member" in Role dropdown of User
+    When user sets "Read Only" in Role dropdown of User
     When user click 'Save' button in User
     And user pause for "5" seconds
     When user close the Notification

--- a/src/features/Configuration.feature
+++ b/src/features/Configuration.feature
@@ -6,7 +6,6 @@ Feature: Configuration
         And user selects "System Administration" on program-selection page
 
     @BI-1502
-        @role
     Scenario Outline: Configuration as a sub-menu
         When user is on the program-management page
         #Create a new program

--- a/src/features/Configuration.feature
+++ b/src/features/Configuration.feature
@@ -6,6 +6,7 @@ Feature: Configuration
         And user selects "System Administration" on program-selection page
 
     @BI-1502
+        @role
     Scenario Outline: Configuration as a sub-menu
         When user is on the program-management page
         #Create a new program
@@ -22,7 +23,7 @@ Feature: Configuration
         When user clicks 'New User' button
         When user sets "Cucumber Breeder" in Name field of User
         When user sets "cucumberbreeder@mailinator.com" in Email field of User
-        When user sets "breeder" in Role dropdown of User
+        When user sets "Program Administrator" in Role dropdown of User
         When user click 'Save' button in User
         When user pause for "10" seconds
         When user close notification pop-up

--- a/src/features/ExperimentsImport.feature
+++ b/src/features/ExperimentsImport.feature
@@ -22,7 +22,7 @@ Feature: Experiments & Observations
         When user clicks 'New User' button
         When user sets "Cucumber Breeder" in Name field of User
         When user sets "cucumberbreeder@mailinator.com" in Email field of User
-        When user sets "breeder" in Role dropdown of User
+        When user sets "Program Administrator" in Role dropdown of User
         When user click 'Save' button in User
         When user pause for "10" seconds
         When user close notification pop-up
@@ -74,7 +74,7 @@ Feature: Experiments & Observations
         When user clicks 'New User' button
         When user sets "Cucumber Breeder" in Name field of User
         When user sets "cucumberbreeder@mailinator.com" in Email field of User
-        When user sets "breeder" in Role dropdown of User
+        When user sets "Program Administrator" in Role dropdown of User
         When user click 'Save' button in User
         When user pause for "10" seconds
         When user close notification pop-up
@@ -126,7 +126,7 @@ Feature: Experiments & Observations
         When user clicks 'New User' button
         When user sets "Cucumber Breeder" in Name field of User
         When user sets "cucumberbreeder@mailinator.com" in Email field of User
-        When user sets "breeder" in Role dropdown of User
+        When user sets "Program Administrator" in Role dropdown of User
         When user click 'Save' button in User
         When user pause for "10" seconds
         When user close notification pop-up
@@ -177,7 +177,7 @@ Feature: Experiments & Observations
         When user clicks 'New User' button
         When user sets "Cucumber Breeder" in Name field of User
         When user sets "cucumberbreeder@mailinator.com" in Email field of User
-        When user sets "breeder" in Role dropdown of User
+        When user sets "Program Administrator" in Role dropdown of User
         When user click 'Save' button in User
         When user pause for "10" seconds
         When user close notification pop-up
@@ -230,7 +230,7 @@ Feature: Experiments & Observations
         When user clicks 'New User' button
         When user sets "Cucumber Breeder" in Name field of User
         When user sets "cucumberbreeder@mailinator.com" in Email field of User
-        When user sets "breeder" in Role dropdown of User
+        When user sets "Program Administrator" in Role dropdown of User
         When user click 'Save' button in User
         When user pause for "10" seconds
         When user close notification pop-up

--- a/src/features/GermplasmImportTable.feature
+++ b/src/features/GermplasmImportTable.feature
@@ -18,7 +18,7 @@ Feature: Germplasm Import Table
         When user clicks 'New User' button
         When user sets "Cucumber Breeder" in Name field of User
         When user sets "cucumberbreeder@mailinator.com" in Email field of User
-        When user sets "breeder" in Role dropdown of User
+        When user sets "Program Administrator" in Role dropdown of User
         When user click 'Save' button in User
         When user pause for "10" seconds
         When user close notification pop-up

--- a/src/features/GermplasmSort.feature
+++ b/src/features/GermplasmSort.feature
@@ -1,6 +1,7 @@
 Feature: Germplasm Sort Test
 
 	@BI-1588
+		@role
 	Scenario: Easily able to sort the germplasm in the germplasm table
 		#Create a new program
 		Given user logs in as "sysad"
@@ -19,7 +20,7 @@ Feature: Germplasm Sort Test
 		When user clicks 'New User' button
 		When user sets "Cucumber Breeder" in Name field of User
 		When user sets "cucumberbreeder@mailinator.com" in Email field of User
-		When user sets "breeder" in Role dropdown of User
+		When user sets "Program Administrator" in Role dropdown of User
 		When user click 'Save' button in User
 		When user pause for "10" seconds
 		When user close notification pop-up

--- a/src/features/GermplasmSort.feature
+++ b/src/features/GermplasmSort.feature
@@ -1,7 +1,6 @@
 Feature: Germplasm Sort Test
 
 	@BI-1588
-		@role
 	Scenario: Easily able to sort the germplasm in the germplasm table
 		#Create a new program
 		Given user logs in as "sysad"

--- a/src/features/GermplasmTable.feature
+++ b/src/features/GermplasmTable.feature
@@ -20,7 +20,7 @@ Feature: Germplasm table loading message
         When user clicks 'New User' button
         When user sets "Cucumber Breeder" in Name field of User
         When user sets "cucumberbreeder@mailinator.com" in Email field of User
-        When user sets "breeder" in Role dropdown of User
+        When user sets "Program Administrator" in Role dropdown of User
         When user click 'Save' button in User
         When user pause for "10" seconds
         When user close notification pop-up
@@ -77,7 +77,7 @@ Feature: Germplasm table loading message
         When user clicks 'New User' button
         When user sets "Cucumber Breeder" in Name field of User
         When user sets "cucumberbreeder@mailinator.com" in Email field of User
-        When user sets "breeder" in Role dropdown of User
+        When user sets "Program Administrator" in Role dropdown of User
         When user click 'Save' button in User
         When user pause for "10" seconds
         When user close notification pop-up

--- a/src/features/LoginByRoleAdminTests.feature
+++ b/src/features/LoginByRoleAdminTests.feature
@@ -3,9 +3,9 @@ Feature: Logging with Sys Administration
 	Background: Required Setup
 		Given user logs in as "sysad"
 		And user selects "System Administration" on program-selection page
-		And user can see "Cucumber Breeder" has been added to "Snacks" as a breeder
-		And user can see "Cucumber Breeder" has been added to "Trail Mix" as a member
-		And user can see "TrailMix Breeder" has been added to "Trail Mix" as a breeder
+		And user can see "Cucumber Breeder" has been added to "Snacks" as a Program Administrator
+		And user can see "Cucumber Breeder" has been added to "Trail Mix" as a Read Only
+		And user can see "TrailMix Breeder" has been added to "Trail Mix" as a Program Administrator
 		And user can see "Snacks" as a program
 
 	@BI-817

--- a/src/features/LoginByRoleMemberTests.feature
+++ b/src/features/LoginByRoleMemberTests.feature
@@ -1,7 +1,7 @@
-Feature: Logging with Member
+Feature: Logging with Read Only
 
 	@BI-822
-	Scenario: Logging in as a member of one program
+	Scenario: Logging in as a Read Only of one program
 		Given user logs in as "Cucumber Member"
 		When user selects "Snacks" on program-selection page
 		Then user can see Welcome page of program
@@ -15,7 +15,7 @@ Feature: Logging with Member
 		And user can see "Program Administration" in navigation
 
 	@BI-823
-	Scenario: Logging in as a breeder of one program
+	Scenario: Logging in as a Read Only of one program
 		Given user logs in as "Cucumber Member"
 		When user selects "Snacks" on program-selection page
 		Then user can see Welcome page of program
@@ -28,14 +28,14 @@ Feature: Logging with Member
 		And user can see "Program Administration" in navigation
 
 	@BI-845
-	Scenario: Logging in as a breeder of one program
+	Scenario: Logging in as a Read Only of one program
 		Given user logs in as "Cucumber Member"
 		When user selects "Snacks" on program-selection page
 		When user selects "Ontology" in navigation
 		Then user can not see "Import Ontology" in navigation
 
 	@BI-887
-	Scenario: No Admin role, Program Member - Program User Management
+	Scenario: No System Admin role, Program Read Only - Program User Management
 		Given user logs in as "Cucumber Member"
 		When user selects "Snacks" on program-selection page
 		And user selects "Program Administration" in navigation
@@ -47,7 +47,7 @@ Feature: Logging with Member
 	#To ensure there is at least one location in list of locations in Snacks
 	#Scenario will still pass with no locations, but won't test the lack of Edit and Deactivate links
 	@BI-915
-	Scenario: Program Location Management page - member - SETUP
+	Scenario: Program Location Management page - Read Only - SETUP
 		Given user logs in as "Cucumber Breeder"
 		When user selects "Snacks" on program-selection page
 		When user selects "Program Administration" in navigation
@@ -60,7 +60,7 @@ Feature: Logging with Member
 			| Location*     |
 
 	@BI-915
-	Scenario: Program Location Management page - member
+	Scenario: Program Location Management page - Read Only
 		Given user logs in as "Cucumber Member"
 		When user selects "Snacks" on program-selection page
 		And user selects "Program Administration" in navigation

--- a/src/features/OntologyImportPreview.feature
+++ b/src/features/OntologyImportPreview.feature
@@ -21,7 +21,7 @@ Feature: Ontology Import Preview
         When user clicks 'New User' button
         When user sets "Cucumber Breeder" in Name field of User
         When user sets "cucumberbreeder@mailinator.com" in Email field of User
-        When user sets "breeder" in Role dropdown of User
+        When user sets "Program Administrator" in Role dropdown of User
         When user click 'Save' button in User
         When user pause for "10" seconds
         When user close notification pop-up

--- a/src/features/SmokeTests.feature
+++ b/src/features/SmokeTests.feature
@@ -11,7 +11,6 @@ Feature: Smoke Tests (11)
 		Then user can see a new program is created
 
 	@BI-806
-		@role
 	Scenario Outline: New Program User
 		Given user logs in as "Cucumber Breeder"
 		When user selects "Snacks" on program-selection page

--- a/src/features/SmokeTests.feature
+++ b/src/features/SmokeTests.feature
@@ -11,6 +11,7 @@ Feature: Smoke Tests (11)
 		Then user can see a new program is created
 
 	@BI-806
+		@role
 	Scenario Outline: New Program User
 		Given user logs in as "Cucumber Breeder"
 		When user selects "Snacks" on program-selection page
@@ -29,7 +30,7 @@ Feature: Smoke Tests (11)
 
 		Examples:
 			| Name   | Email                | Role    |
-			| Test * | test*@mailinator.com | breeder |
+			| Test * | test*@mailinator.com | Program Administrator |
 
 	@BI-806
 	Scenario: Check Users page

--- a/src/features/UserManagementBreeder.feature
+++ b/src/features/UserManagementBreeder.feature
@@ -100,6 +100,7 @@ Feature: Breeder User Management
 		And user can see 'Role is required' below the Role field
 
 	@BI-892
+		@role
 	Scenario: New User form - enter all required, valid fields - Cancel
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -108,12 +109,13 @@ Feature: Breeder User Management
 		And user selects New User button
 		And user sets "Tester Breeder" in Name field
 		And user sets "testnewuser@mail.com" in Email field
-		And user sets "breeder" in Role dropdown
+		And user sets "Program Administrator" in Role dropdown
 		And user selects Cancel button
 		Then user does not see new user form
 		And user does not see a new user in Users list
 
 	@BI-893
+		@role
 	Scenario: New User form - enter all required, valid fields - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -121,10 +123,11 @@ Feature: Breeder User Management
 		And user selects "Users" tab
 		When user creates a new user
 			| Name   | Email                | Role    |
-			| Test * | test*@mailinator.com | breeder |
+			| Test * | test*@mailinator.com | Program Administrator |
 		Then user can see a new user is added in User
 
 	@BI-894
+		@role
 	Scenario: NEW Program User form - enter invalid email address - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -133,12 +136,13 @@ Feature: Breeder User Management
 		And user selects New User button
 		And user sets "Tester Breeder" in Name field
 		And user sets "testnewuser" in Email field
-		And user sets "breeder" in Role dropdown
+		And user sets "Program Administrator" in Role dropdown
 		And user selects Save button
 		Then user can see banner appears with an error message "Fix Invalid Fields"
 		Then user can see 'Email must be in email format' below the Email field
 
 	@BI-896
+		@role
 	Scenario: NEW User form - enter existing email address - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -147,12 +151,13 @@ Feature: Breeder User Management
 		When user selects New User button
 		And user sets "TestNewUser" in Name field
 		And user sets "cucumberbreeder@mailinator.com" in Email field
-		And user sets "breeder" in Role dropdown
+		And user sets "Program Administrator" in Role dropdown
 		And user selects Save button
 		Then user can see banner appears with an error message "Error creating user, a user with this email already exists"
 		Then user can see new user form
 
 	@BI-897
+		@role
 	Scenario: Edit Form elements
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -160,13 +165,14 @@ Feature: Breeder User Management
 		And user selects "Users" tab
 		When user creates a new user
 			| Name   | Email                | Role    |
-			| Test * | test*@mailinator.com | breeder |
+			| Test * | test*@mailinator.com | Program Administrator |
 		And user clicks Edit of a user
-		Then user can see "breeder" in the the Role dropdown
+		Then user can see "Program Administrator" in the the Role dropdown
 		Then user can see Save button
 		Then user can see Cancel button
 
 	@BI-898
+		@role
 	Scenario: Edit Form - change role - Cancel
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -174,12 +180,13 @@ Feature: Breeder User Management
 		And user selects "Users" tab
 		When user creates a new user
 			| Name   | Email                | Role    |
-			| Test * | test*@mailinator.com | breeder |
+			| Test * | test*@mailinator.com | Program Administrator |
 		And user clicks Edit of a user
 		And user selects Cancel button
 		Then user can see user is in users list
 
 	@BI-899
+		@role
 	Scenario: Edit Form - change role - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -187,13 +194,14 @@ Feature: Breeder User Management
 		And user selects "Users" tab
 		When user creates a new user
 			| Name   | Email                | Role    |
-			| Test * | test*@mailinator.com | breeder |
+			| Test * | test*@mailinator.com | Program Administrator |
 		And user edits a user
 			| Role   |
-			| member |
+			| Read Only |
 		Then user can see user is in users list
 
 	@BI-900
+		@role
 	Scenario Outline: Deactivate link - modal
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -201,7 +209,7 @@ Feature: Breeder User Management
 		And user selects "Users" tab
 		And user creates a new user
 			| Name  | Email                | Role    |
-			| User* | test*@mailinator.com | breeder |
+			| User* | test*@mailinator.com | Program Administrator |
 		When user selects Deactivate of user
 		Then user can see "Deactivate" in modal box header
 		Then user can see "<NameToDeactivate>" in modal box header
@@ -216,6 +224,7 @@ Feature: Breeder User Management
 			| User*            |
 
 	@BI-901
+		@role
 	Scenario: Deactivate link - Cancel
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -223,13 +232,14 @@ Feature: Breeder User Management
 		And user selects "Users" tab
 		And user creates a new user
 			| Name   | Email                | Role    |
-			| Test * | test*@mailinator.com | breeder |
+			| Test * | test*@mailinator.com | Program Administrator |
 		When user selects Deactivate of user
 		And user can see 'Cancel' button
 		And user selects "Cancel" button
 		Then user can see user is in users list
 
 	@BI-902
+		@role
 	Scenario: Deactivate link - Yes, deactivate
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -237,27 +247,30 @@ Feature: Breeder User Management
 		And user selects "Users" tab
 		And user creates a new user
 			| Name   | Email                | Role    |
-			| Test * | test*@mailinator.com | breeder |
+			| Test * | test*@mailinator.com | Program Administrator |
 		When user selects Deactivate of user
 		And user selects modal Yes, archive button
 		Then user can not see user is in users list
 
 	@BI-903
+		@role
 	Scenario: admin editing self - Program User management
 		Given user logs in as "sysad"
 		And user selects "Snacks" on program-selection page
 		And user selects "Program Administration" in navigation
 		And user selects "Users" tab
 		When user selects "Edit" of Name "Christian"
-		When user selects "member" in Role dropdown
+		When user selects "Read Only" in Role dropdown
 		When user selects "Save" button
 		Then user can see banner contains "Success"
 		When user selects "Edit" of Name "Christian"
-		When user selects "breeder" in Role dropdown
+		When user selects "Program Administrator" in Role dropdown
 		When user selects "Save" button
 		Then user can see banner contains "Success"
 
 	@BI-904
+		@role
+		##todo check if this is intended behavior
 	Scenario: breeder with no admin role editing self - Program User management
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page

--- a/src/features/UserManagementBreeder.feature
+++ b/src/features/UserManagementBreeder.feature
@@ -100,7 +100,6 @@ Feature: Breeder User Management
 		And user can see 'Role is required' below the Role field
 
 	@BI-892
-		@role
 	Scenario: New User form - enter all required, valid fields - Cancel
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -115,7 +114,6 @@ Feature: Breeder User Management
 		And user does not see a new user in Users list
 
 	@BI-893
-		@role
 	Scenario: New User form - enter all required, valid fields - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -127,7 +125,6 @@ Feature: Breeder User Management
 		Then user can see a new user is added in User
 
 	@BI-894
-		@role
 	Scenario: NEW Program User form - enter invalid email address - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -142,7 +139,6 @@ Feature: Breeder User Management
 		Then user can see 'Email must be in email format' below the Email field
 
 	@BI-896
-		@role
 	Scenario: NEW User form - enter existing email address - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -157,7 +153,6 @@ Feature: Breeder User Management
 		Then user can see new user form
 
 	@BI-897
-		@role
 	Scenario: Edit Form elements
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -172,7 +167,6 @@ Feature: Breeder User Management
 		Then user can see Cancel button
 
 	@BI-898
-		@role
 	Scenario: Edit Form - change role - Cancel
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -186,7 +180,6 @@ Feature: Breeder User Management
 		Then user can see user is in users list
 
 	@BI-899
-		@role
 	Scenario: Edit Form - change role - Save
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -201,7 +194,6 @@ Feature: Breeder User Management
 		Then user can see user is in users list
 
 	@BI-900
-		@role
 	Scenario Outline: Deactivate link - modal
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -224,7 +216,6 @@ Feature: Breeder User Management
 			| User*            |
 
 	@BI-901
-		@role
 	Scenario: Deactivate link - Cancel
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -239,7 +230,6 @@ Feature: Breeder User Management
 		Then user can see user is in users list
 
 	@BI-902
-		@role
 	Scenario: Deactivate link - Yes, deactivate
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page
@@ -253,7 +243,6 @@ Feature: Breeder User Management
 		Then user can not see user is in users list
 
 	@BI-903
-		@role
 	Scenario: admin editing self - Program User management
 		Given user logs in as "sysad"
 		And user selects "Snacks" on program-selection page
@@ -269,8 +258,6 @@ Feature: Breeder User Management
 		Then user can see banner contains "Success"
 
 	@BI-904
-		@role
-		##todo check if this is intended behavior
 	Scenario: breeder with no admin role editing self - Program User management
 		Given user logs in as "Cucumber Breeder"
 		And user selects "Snacks" on program-selection page

--- a/src/features/UserManagementSysAd.feature
+++ b/src/features/UserManagementSysAd.feature
@@ -76,7 +76,6 @@ Feature: System User Management (15)
 		Then user can see a new user is added in User
 
 	@BI-831
-		@role
 	Scenario:  Adding new user with admin role
 		Given user is on the user-management page
 		When user creates a new user
@@ -85,7 +84,6 @@ Feature: System User Management (15)
 		Then user can see a new user is added in User
 
 	@BI-832
-		@role
 	Scenario: Filling out new user form and selecting Cancel
 		Given user is on the user-management page
 		When user selects New User button
@@ -98,7 +96,6 @@ Feature: System User Management (15)
 
 	@BI-833
 	@BI-835
-		@role
 	Scenario: Edit form entities
 		Given user is on the user-management page
 		When user creates a new user
@@ -110,9 +107,6 @@ Feature: System User Management (15)
 		Then user can see edited user in users list
 
 	@BI-834
-		@role
-		##todo possible need to fix quotes depending on how step definition handled
-		##todo possible creating a user needs to be fixed for taf setup
 	Scenario: Editing form and selecting Cancel
 		Given user is on the user-management page
 		When user creates a new user
@@ -123,7 +117,6 @@ Feature: System User Management (15)
 		Then user can see user is in users list
 
 	@BI-838
-		@role
 	Scenario Outline: Deactivate link - modal
 		Given user is on the user-management page
 		And user creates a new user
@@ -144,7 +137,6 @@ Feature: System User Management (15)
 			| Test *       |
 
 	@BI-839
-		@role
 	Scenario: User Deactivate link and Cancel
 		Given user is on the user-management page
 		And user creates a new user
@@ -157,7 +149,6 @@ Feature: System User Management (15)
 		Then user can see edited user in users list
 
 	@BI-840
-		@role
 	Scenario: Deactivate link - Yes, deactivate
 		Given user is on the user-management page
 		And user creates a new user

--- a/src/features/UserManagementSysAd.feature
+++ b/src/features/UserManagementSysAd.feature
@@ -76,14 +76,16 @@ Feature: System User Management (15)
 		Then user can see a new user is added in User
 
 	@BI-831
+		@role
 	Scenario:  Adding new user with admin role
 		Given user is on the user-management page
 		When user creates a new user
 			| Name   | Email                | Role  |
-			| Test * | test*@mailinator.com | admin |
+			| Test * | test*@mailinator.com | System Administrator |
 		Then user can see a new user is added in User
 
 	@BI-832
+		@role
 	Scenario: Filling out new user form and selecting Cancel
 		Given user is on the user-management page
 		When user selects New User button
@@ -96,32 +98,37 @@ Feature: System User Management (15)
 
 	@BI-833
 	@BI-835
+		@role
 	Scenario: Edit form entities
 		Given user is on the user-management page
 		When user creates a new user
 			| Name   | Email                | Role  |
-			| Test * | test*@mailinator.com | admin |
+			| Test * | test*@mailinator.com | System Administrator |
 		And user edits a user
 			| Name   | Email                | Role |
 			| Test * | test*@mailinator.com |      |
 		Then user can see edited user in users list
 
 	@BI-834
+		@role
+		##todo possible need to fix quotes depending on how step definition handled
+		##todo possible creating a user needs to be fixed for taf setup
 	Scenario: Editing form and selecting Cancel
 		Given user is on the user-management page
 		When user creates a new user
 			| Name   | Email                | Role  |
-			| Test * | test*@mailinator.com | admin |
+			| Test * | test*@mailinator.com | System Administrator |
 		And user clicks Edit of a user
 		And user selects Cancel button
 		Then user can see user is in users list
 
 	@BI-838
+		@role
 	Scenario Outline: Deactivate link - modal
 		Given user is on the user-management page
 		And user creates a new user
 			| Name   | Email                | Role    |
-			| <NameToDeactivate> | test*@mailinator.com | breeder |
+			| <NameToDeactivate> | test*@mailinator.com | System Administrator |
 		When user selects Deactivate of user
 		Then user can see "Deactivate" in modal box header
 		And user can see "<NameToDeactivate>" in modal box header
@@ -137,11 +144,12 @@ Feature: System User Management (15)
 			| Test *       |
 
 	@BI-839
+		@role
 	Scenario: User Deactivate link and Cancel
 		Given user is on the user-management page
 		And user creates a new user
 			| Name       | Email                | Role    |
-			| User* | test*@mailinator.com | breeder |
+			| User* | test*@mailinator.com | System Administrator |
 		When user selects Deactivate of user
 		Then user can see a modal box
 		When user selects 'Cancel' button
@@ -149,11 +157,12 @@ Feature: System User Management (15)
 		Then user can see edited user in users list
 
 	@BI-840
+		@role
 	Scenario: Deactivate link - Yes, deactivate
 		Given user is on the user-management page
 		And user creates a new user
 			| Name   | Email                | Role    |
-			| Test * | test*@mailinator.com | breeder |
+			| Test * | test*@mailinator.com | System Administrator |
 		When user selects Deactivate of user
 		When user selects 'Yes, deactivate' button
 		Then user can not see user is in users list

--- a/src/step_definitions/steps.js
+++ b/src/step_definitions/steps.js
@@ -611,7 +611,7 @@ When(/^user can see "([^"]*)" as a program$/, async (args1) => {
 });
 
 When(
-  /^user can see "([^"]*)" has been added to "([^"]*)" as a breeder$/,
+  /^user can see "([^"]*)" has been added to "([^"]*)" as a Program Administrator$/,
   async (args1, args2) => {
     await page.navigateToProgram(args2);
 
@@ -635,7 +635,7 @@ When(
 );
 
 When(
-  /^user can see "([^"]*)" has been added to "([^"]*)" as a member$/,
+  /^user can see "([^"]*)" has been added to "([^"]*)" as a Read Only$/,
   async (args1, args2) => {
     await page.navigateToProgram(args2);
 

--- a/src/step_definitions/steps.js
+++ b/src/step_definitions/steps.js
@@ -1148,15 +1148,15 @@ Given(/^a new program is created$/, async function () {
   await navigateOnLeftMenu("Program Administration");
   await clickTab("Users");
   await clickNewUserButton();
-  await setUserName("Breeder");
+  await setUserName("ProgramAdmin");
   await setEmail("cucumberbreeder@mailinator.com");
-  await setRole("Breeder");
+  await setRole("Program Administrator");
   await clickSaveUserButton();
   await page.pause(1000);
   await clickNewUserButton();
-  await setUserName("Member");
+  await setUserName("ReadOnly");
   await setEmail("cucumbermember@mailinator.com");
-  await setRole("Member");
+  await setRole("Read Only");
   await clickSaveUserButton();
   await page.pause(1000);
 

--- a/src/step_definitions/steps.js
+++ b/src/step_definitions/steps.js
@@ -628,7 +628,7 @@ When(
       locateStrategy: "xpath",
     });
     await page.waitForElementVisible({
-      selector: `//*[@id='programUserTableLabel']//tr//td[normalize-space(.)='${args1}']/following-sibling::td[normalize-space(.)='breeder']`,
+      selector: `//*[@id='programUserTableLabel']//tr//td[normalize-space(.)='${args1}']/following-sibling::td[normalize-space(.)='Program Administrator']`,
       locateStrategy: "xpath",
     });
   }
@@ -652,7 +652,7 @@ When(
       locateStrategy: "xpath",
     });
     await page.waitForElementVisible({
-      selector: `//*[@id='programUserTableLabel']//tr//td[normalize-space(.)='${args1}']/following-sibling::td[normalize-space(.)='member']`,
+      selector: `//*[@id='programUserTableLabel']//tr//td[normalize-space(.)='${args1}']/following-sibling::td[normalize-space(.)='Read Only']`,
       locateStrategy: "xpath",
     });
   }


### PR DESCRIPTION
# Description
**Story:** [BI-1692 - Change role names](https://breedinginsight.atlassian.net/browse/BI-1692)
TAF changes in response to changing role domains as follows:
- admin -> System Administrator
- breeder -> Program Administrator
- member -> Read Only

Areas updated to use new role domains:
- README
- populate-taf-data.sql
- Features
- Step definitions

# Dependencies
bi-web: [feature/BI-1692](https://github.com/Breeding-Insight/bi-web/pull/388)
bi-api: [feature/BI-1692](https://github.com/Breeding-Insight/bi-api/pull/377)

# Testing
[_Please include a link to a successful run of TAF for this change_](https://github.com/Breeding-Insight/taf/actions/runs/10199847184)


# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to documentation
