### PR TITLE
updated docker compose command

### DIFF
--- a/.github/workflows/daily-test.yml
+++ b/.github/workflows/daily-test.yml
@@ -104,7 +104,7 @@ jobs:
           java-version: 13
 
         #from bi-docker-stack
-      - run: docker-compose -f bi-docker-stack/docker-compose.yml -f bi-docker-stack/docker-compose-redis.yml -f bi-docker-stack/docker-compose-gigwa.yml -f bi-docker-stack/docker-compose-qa.yml up -d
+      - run: docker compose -f bi-docker-stack/docker-compose.yml -f bi-docker-stack/docker-compose-redis.yml -f bi-docker-stack/docker-compose-gigwa.yml -f bi-docker-stack/docker-compose-qa.yml up -d
 
       - name: Set up Chrome
         uses: browser-actions/setup-chrome@latest

--- a/.github/workflows/test-branch.yml
+++ b/.github/workflows/test-branch.yml
@@ -130,7 +130,7 @@ jobs:
           java-version: 13
 
         #from bi-docker-stack
-      - run: docker-compose -f bi-docker-stack/docker-compose.yml -f bi-docker-stack/docker-compose-redis.yml -f bi-docker-stack/docker-compose-gigwa.yml -f bi-docker-stack/docker-compose-ci.yml up --build -d
+      - run: docker compose -f bi-docker-stack/docker-compose.yml -f bi-docker-stack/docker-compose-redis.yml -f bi-docker-stack/docker-compose-gigwa.yml -f bi-docker-stack/docker-compose-ci.yml up --build -d
 
       - name: Set up Chrome
         uses: browser-actions/setup-chrome@latest


### PR DESCRIPTION
Updated the old `docker-compose` command to use the new `docker compose`.

It seems GitHub Actions must have started using a newer version of the docker cli.

The TAF run made it past the docker compose command, so I think this fixed that specific issue. https://github.com/Breeding-Insight/taf/actions/runs/10287092389/job/28469312179