### PR TITLE
Feature/bi 2056

### DIFF
--- a/src/features/BI-2056.feature
+++ b/src/features/BI-2056.feature
@@ -37,9 +37,3 @@ Feature: The ontology can be case insensitive
     And user can see "Blackberry" column header
     And user can see "Blackberry1" column header
     And user can see "Blackberry01" column header
-        # Then user can see "Full Name" column header
-        # Then user pause for "5" seconds
-        # When user selects "Full Name" column header
-        # Then user can see "Full Name" sort on column header
-        # When user selects 'Show details' button of "Blackberry1" on ontology list page
-        # Then user can see "Test" in Full Name field of Show Details on ontology list page

--- a/src/features/BI-2056.feature
+++ b/src/features/BI-2056.feature
@@ -1,27 +1,42 @@
 Feature: The ontology can be case insensitive
 
-  Background: 
-        Given a new program is created
+  Background:
+    Given a new program is created
 
-    @BI-2156
-    @debug
-    Scenario Outline: The ontology can be case insensitive
-        Given user logs in as "Cucumber Breeder"
-        When user selects "*" on program-selection page
-        # And user selects "Germplasm" in navigation
-        # And user selects "Manage Germplasm" button
-        # And user selects "Import file" menu item 
-        # And user uploads Germplasm "GermplasmSample.xlsx" file
-        # And user selects 'Import' button
-        # When user sets "GermplasmSort" in List Name field of import page
-        # When user sets "GermplasmSort" in List Description field of import page
-        # And user selects "Confirm" button
-        # When user selects "Ontology" in navigation
-        # When user selects "Manage Ontology" button
-        # When user selects "Import file" link
-        # And user uploads Ontology "test01-ontology.xls" file
-        # When user selects 'Import' button
-        # When user selects "Confirm" button
+  @BI-2156 @debug
+  Scenario Outline: The ontology can be case insensitive
+    Given user logs in as "Cucumber Breeder"
+    When user selects "*" on program-selection page
+    And user selects "Germplasm" in navigation
+    And user selects "Manage Germplasm" button
+    And user selects "Import file" menu item
+    And user uploads Germplasm "GermplasmSample.xlsx" file
+    And user selects 'Import' button
+    When user sets "GermplasmSort" in List Name field of import page
+    When user sets "GermplasmSort" in List Description field of import page
+    And user selects "Confirm" button
+    When user selects "Ontology" in navigation
+    When user selects "Manage Ontology" button
+    When user selects "Import file" link
+    And user uploads Ontology "test01-ontology.xls" file
+    When user selects 'Import' button
+    When user selects "Confirm" button
+    And user pause for "5" seconds
+    When user selects "Experiments & Observations" in navigation
+    When user selects "Import Experiments & Observations" button
+    And user uploads Experiments & Observations "BI-2056.csv" file
+    When user selects 'Import' button
+    When user pause for "10" seconds
+    And user can see "BLACKBERRY" column header
+    And user can see "BlackBERRY1" column header
+    And user can see "blackberry01" column header
+    And user selects "Confirm" button
+    When user pause for "10" seconds
+    When user selects "Experiments & Observations" in navigation
+    When user selects "New Trial DRP1" of row "1" of Experiments page
+    And user can see "Blackberry" column header
+    And user can see "Blackberry1" column header
+    And user can see "Blackberry01" column header
         # Then user can see "Full Name" column header
         # Then user pause for "5" seconds
         # When user selects "Full Name" column header

--- a/src/features/BI-2056.feature
+++ b/src/features/BI-2056.feature
@@ -1,0 +1,30 @@
+Feature: The ontology can be case insensitive
+
+  Background: 
+        Given a new program is created
+
+    @BI-2156
+    @debug
+    Scenario Outline: The ontology can be case insensitive
+        Given user logs in as "Cucumber Breeder"
+        When user selects "*" on program-selection page
+        # And user selects "Germplasm" in navigation
+        # And user selects "Manage Germplasm" button
+        # And user selects "Import file" menu item 
+        # And user uploads Germplasm "GermplasmSample.xlsx" file
+        # And user selects 'Import' button
+        # When user sets "GermplasmSort" in List Name field of import page
+        # When user sets "GermplasmSort" in List Description field of import page
+        # And user selects "Confirm" button
+        # When user selects "Ontology" in navigation
+        # When user selects "Manage Ontology" button
+        # When user selects "Import file" link
+        # And user uploads Ontology "test01-ontology.xls" file
+        # When user selects 'Import' button
+        # When user selects "Confirm" button
+        # Then user can see "Full Name" column header
+        # Then user pause for "5" seconds
+        # When user selects "Full Name" column header
+        # Then user can see "Full Name" sort on column header
+        # When user selects 'Show details' button of "Blackberry1" on ontology list page
+        # Then user can see "Test" in Full Name field of Show Details on ontology list page

--- a/src/features/BI-2160.feature
+++ b/src/features/BI-2160.feature
@@ -4,7 +4,6 @@ Feature: Display the full name in the table and details pane for ontology
         Given a new program is created
 
     @BI-2160
-    @debug
     Scenario Outline: Display the full name in the table and details pane for ontology
         Given user logs in as "Cucumber Breeder"
         When user selects "*" on program-selection page

--- a/src/features/BI-2164.feature
+++ b/src/features/BI-2164.feature
@@ -4,7 +4,6 @@ Background: Create a new list referencing existing GIDs
       
 
     @BI-2164
-    @debug
     @BUG_BI-2260
     Scenario Outline: All of the information associated with a Germplasm Details page
         Given a new program is created

--- a/src/files/ExperimentsImport/BI-2056.csv
+++ b/src/files/ExperimentsImport/BI-2056.csv
@@ -1,0 +1,5 @@
+Germplasm Name,Germplasm GID,Test (T) or Check (C),Exp Title ,Exp Description,Exp Unit,Exp Type,Env,Env Location,Env Year,Exp Unit ID,Exp Replicate #,Exp Block #,Row,Column,Lat,Long,Elevation,RTK,Treatment Factors,ObsUnitID,BLACKBERRY,BlackBERRY1,blackberry01
+Germplas127,1,C,New Trial DRP1,A new trial DRP,plot,phenotyping,New Study 15,New Location DRP6,2000,9390,1,2,4,5,,,,,Jam application,,,,
+Germplas128,2,C,New Trial DRP1,A new trial DRP,plot,phenotyping,New Study 16,New Location DRP7,2000,9391,1,2,4,5,,,,,Jam application,,,,
+Germplas129,3,C,New Trial DRP1,A new trial DRP,plot,phenotyping,New Study 17,New Location DRP8,2000,9392,1,2,4,5,,,,,Jam application,,,,
+Germplas130,4,C,New Trial DRP1,A new trial DRP,plot,phenotyping,New Study 18,New Location DRP9,2000,9393,1,2,4,5,,,,,Jam application,,,,

--- a/src/step_definitions/experimentsObservationsSteps.js
+++ b/src/step_definitions/experimentsObservationsSteps.js
@@ -1,0 +1,14 @@
+const { client } = require("nightwatch-api");
+const { Then, When } = require("@cucumber/cucumber");
+const experimentsObservationPage = client.page.experimentsObservationsPage();
+const helpers = require("./helpers");
+
+When(
+    /^user selects "([^"]*)" of row "([^"]*)" of Experiments page$/,
+    async function (link, rowIndex) {
+      await experimentsObservationPage.section.table.click({
+        selector: `.//tr[${rowIndex}]//a[normalize-space()='${link}']`,
+        locateStrategy: "xpath",
+      });
+    }
+  );


### PR DESCRIPTION
# Description
BI-2056 - The ontology can be case insensitive
Add step definition for clicking a row of an Ontology.

# Testing
[_Please include a link to a successful run of TAF for this change_](https://github.com/Breeding-Insight/taf/actions/runs/10787725833)


# Checklist:

- [x ] I have performed a self-review of my own code
- [ ] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to documentation
